### PR TITLE
fix: harden runtime audit findings and add regression coverage

### DIFF
--- a/src/components/settings/replacement-section.tsx
+++ b/src/components/settings/replacement-section.tsx
@@ -4,15 +4,11 @@ import { useEffect, useRef } from 'preact/hooks'
 import { ensureRoomId, getCsrfToken, sendDanmaku } from '../../lib/api'
 import { BASE_URL } from '../../lib/const'
 import { appendLog } from '../../lib/log'
+import { type RemoteKeywords, sanitizeRemoteKeywords } from '../../lib/remote-keywords-sanitize'
 import { buildReplacementMap } from '../../lib/replacement'
 import { cachedRoomId, localGlobalRules, localRoomRules, remoteKeywords, remoteKeywordsLastSync } from '../../lib/store'
 
 const SYNC_INTERVAL = 10 * 60 * 1000
-
-interface RemoteKeywords {
-  global?: { keywords?: Record<string, string> }
-  rooms?: Array<{ room: string; keywords?: Record<string, string> }>
-}
 
 interface ReplacementRule {
   from?: string
@@ -22,7 +18,8 @@ interface ReplacementRule {
 async function fetchRemoteKeywords(): Promise<RemoteKeywords> {
   const response = await fetch(BASE_URL.REMOTE_KEYWORDS)
   if (!response.ok) throw new Error(`HTTP ${response.status}: ${response.statusText}`)
-  return await response.json()
+  const raw: unknown = await response.json()
+  return sanitizeRemoteKeywords(raw)
 }
 
 function ReplacementRuleList({

--- a/src/lib/ai-evasion.ts
+++ b/src/lib/ai-evasion.ts
@@ -43,12 +43,25 @@ export function processText(text: string): string {
   return insertInvisibleChars(text)
 }
 
-function replaceSensitiveWords(text: string, sensitiveWords: string[]): string {
+export function replaceSensitiveWords(text: string, sensitiveWords: string[]): string {
   let result = text
   for (const word of sensitiveWords) {
+    if (!word) continue
     result = result.split(word).join(processText(word))
   }
   return result
+}
+
+/**
+ * Returns true when the AI-evasion replacement output is safe to enqueue —
+ * i.e. it contains at least one non-whitespace character.
+ *
+ * Without this guard a sensitive-word list that consumes the whole message
+ * (e.g. word === message) would produce an empty string that we'd happily
+ * send as an empty danmaku.
+ */
+export function isEvadedMessageSendable(evadedMessage: string): boolean {
+  return evadedMessage.trim().length > 0
 }
 
 export interface TryAiEvasionResult {
@@ -76,6 +89,14 @@ export async function tryAiEvasion(
     appendLog(`🤖 ${logPrefix}检测到敏感词：${detection.sensitiveWords.join(', ')}，正在尝试规避…`)
 
     const evadedMessage = replaceSensitiveWords(message, detection.sensitiveWords)
+    // Guard against the API returning a sensitive-word list that, after
+    // replacement, leaves nothing meaningful to send. Without this we'd
+    // happily enqueue an empty / whitespace-only danmaku.
+    if (!isEvadedMessageSendable(evadedMessage)) {
+      const error = 'AI规避后内容为空'
+      appendLog(`❌ ${logPrefix}AI规避失败：替换后内容为空，已跳过发送`)
+      return { success: false, evadedMessage, error }
+    }
     if (isLockedEmoticon(evadedMessage)) {
       const error = 'AI规避结果是锁定表情'
       appendLog(formatLockedEmoticonReject(evadedMessage, `${logPrefix}AI规避表情`))

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,3 +1,5 @@
+import { effect } from '@preact/signals'
+
 import type { BilibiliGetEmoticonsResponse } from '../types'
 
 import { BASE_URL } from './const'
@@ -124,6 +126,14 @@ export async function getRoomId(url = window.location.href): Promise<number> {
 // If the user navigates to a different room without a full reload, the slug
 // changes and we invalidate the cache so the next call re-resolves.
 let cachedRoomSlug: string | null = null
+
+// Keep the slug in sync with `cachedRoomId`. If anything outside this module
+// resets `cachedRoomId.value = null` (e.g. an imported settings backup),
+// the slug must reset too — otherwise `ensureRoomId` would happily re-cache
+// the same room id without re-resolving against the current URL.
+effect(() => {
+  if (cachedRoomId.value === null) cachedRoomSlug = null
+})
 
 /**
  * Returns the cached room ID, fetching and caching it if needed.
@@ -303,17 +313,47 @@ function medalEntryToAnchorFallback(entry: unknown): Omit<MedalRoom, 'roomId' | 
   }
 }
 
+const ANCHOR_LOOKUP_TIMEOUT_MS = 8000
+const ANCHOR_LOOKUP_CONCURRENCY = 6
+
 async function fetchRoomByAnchorUid(anchor: Omit<MedalRoom, 'roomId' | 'source'>): Promise<MedalRoom | null> {
-  const resp = await fetch(`${BASE_URL.BILIBILI_ROOM_INFO_BY_UID}?mid=${anchor.anchorUid}`, {
-    method: 'GET',
-    credentials: 'include',
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), ANCHOR_LOOKUP_TIMEOUT_MS)
+  try {
+    const resp = await fetch(`${BASE_URL.BILIBILI_ROOM_INFO_BY_UID}?mid=${anchor.anchorUid}`, {
+      method: 'GET',
+      credentials: 'include',
+      signal: controller.signal,
+    })
+    if (!resp.ok) return null
+    const json: { code?: number; data?: { roomid?: number; link?: string } } = await resp.json()
+    if (json.code !== 0) return null
+    const roomId = toNumber(json.data?.roomid) ?? roomIdFromLiveLink(json.data?.link)
+    if (roomId === null || roomId <= 0) return null
+    return { ...anchor, roomId, source: 'anchor-uid' }
+  } catch {
+    return null
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length)
+  let cursor = 0
+  const workers = new Array(Math.min(limit, items.length)).fill(0).map(async () => {
+    while (true) {
+      const idx = cursor++
+      if (idx >= items.length) return
+      results[idx] = await fn(items[idx])
+    }
   })
-  if (!resp.ok) return null
-  const json: { code?: number; data?: { roomid?: number; link?: string } } = await resp.json()
-  if (json.code !== 0) return null
-  const roomId = toNumber(json.data?.roomid) ?? roomIdFromLiveLink(json.data?.link)
-  if (roomId === null || roomId <= 0) return null
-  return { ...anchor, roomId, source: 'anchor-uid' }
+  await Promise.all(workers)
+  return results
 }
 
 interface FollowingEntry {
@@ -367,8 +407,8 @@ export async function fetchMedalRooms(): Promise<MedalRoom[]> {
     .map(medalEntryToAnchorFallback)
     .filter((anchor): anchor is Omit<MedalRoom, 'roomId' | 'source'> => anchor !== null)
 
-  for (const anchor of unresolvedAnchors) {
-    const room = await fetchRoomByAnchorUid(anchor)
+  const resolved = await mapWithConcurrency(unresolvedAnchors, ANCHOR_LOOKUP_CONCURRENCY, fetchRoomByAnchorUid)
+  for (const room of resolved) {
     if (room) rooms.push(room)
   }
 
@@ -389,13 +429,16 @@ export async function fetchFollowingRooms(maxPages = 4): Promise<FollowingRoom[]
   }
 
   const rooms = new Map<number, FollowingRoom>()
-  for (const anchor of anchors) {
-    const room = await fetchRoomByAnchorUid({
+  const resolved = await mapWithConcurrency(anchors, ANCHOR_LOOKUP_CONCURRENCY, anchor =>
+    fetchRoomByAnchorUid({
       medalName: '',
       anchorName: anchor.anchorName,
       anchorUid: anchor.anchorUid,
-    })
-    if (!room) continue
+    }).then(room => (room ? { room, anchor } : null))
+  )
+  for (const entry of resolved) {
+    if (!entry) continue
+    const { room, anchor } = entry
     rooms.set(room.roomId, {
       roomId: room.roomId,
       anchorName: room.anchorName,

--- a/src/lib/auto-blend.ts
+++ b/src/lib/auto-blend.ts
@@ -746,6 +746,10 @@ export function startAutoBlend(): void {
 
   if (cleanupTimer === null) {
     cleanupTimer = setInterval(() => {
+      // Skip the full pipeline (prune + status format + burst scheduling)
+      // when there's nothing to evaluate. This timer fires once a second for
+      // the entire feature lifetime, including idle rooms.
+      if (trendMap.size === 0) return
       pruneExpired(Date.now())
       updateStatusText()
       maybeScheduleBurstFromCurrentTrends()

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,5 +1,5 @@
 import { GM_getValue, GM_setValue } from '$'
-import { applyImportedSettings } from './gm-signal'
+import { applyImportedSettings, isValidImportedValue } from './gm-signal'
 
 const BACKUP_VERSION = 1
 
@@ -98,12 +98,22 @@ export function importSettings(json: string): { ok: boolean; error?: string; cou
   if (typeof data !== 'object' || data === null || Array.isArray(data)) {
     return { ok: false, error: '数据格式错误，需要 JSON 对象', count: 0 }
   }
+  // Reject backups produced by a newer schema we don't understand. Backups
+  // missing __version are accepted (legacy export).
+  const version = data.__version
+  if (typeof version === 'number' && version > BACKUP_VERSION) {
+    return { ok: false, error: `导入版本 ${version} 高于当前支持的版本 ${BACKUP_VERSION}`, count: 0 }
+  }
   const allowed = new Set<string>(EXPORT_KEYS)
   const toApply: Record<string, unknown> = {}
   let count = 0
   for (const [key, val] of Object.entries(data)) {
     if (key.startsWith('__')) continue
     if (!allowed.has(key)) continue
+    // Drop entries whose imported value doesn't match the in-memory shape.
+    // Without this, a malformed backup could write `msgSendInterval = "5"`
+    // and break the auto-send loop until the user resets the setting.
+    if (!isValidImportedValue(key, val)) continue
     GM_setValue(key, val)
     toApply[key] = val
     count++

--- a/src/lib/custom-chat-dom.ts
+++ b/src/lib/custom-chat-dom.ts
@@ -91,6 +91,11 @@ let disposeSettings: (() => void) | null = null
 let disposeComposer: (() => void) | null = null
 let fallbackMountTimer: ReturnType<typeof setTimeout> | null = null
 let nativeEventObserver: MutationObserver | null = null
+// The container the native observer is currently bound to. Used so we can
+// re-connect after suspending the observer while WS is live.
+let nativeEventObserverContainer: HTMLElement | null = null
+// Track suspension state so updateWsStatus can flip the observer on/off.
+let nativeEventObserverSuspended = false
 let root: HTMLElement | null = null
 let rootOutsideHistory = false
 let rootUsesFallbackHost = false
@@ -123,6 +128,15 @@ let nativeDomWarning = false
 const messages: CustomChatEvent[] = []
 const messageKeys = new Set<string>()
 const recentEventKeys = new Map<string, number>()
+// Cache `eventKey(message)` per message ref to avoid recomputing the regex
+// inside `compactText` on every dedup scan.
+const eventKeyByMessage = new WeakMap<CustomChatEvent, string>()
+// Map from eventKey → most-recent message that produced it. O(1) duplicate
+// lookup in `messageIndexByEvent`. The array index is recovered via indexOf
+// only on the (rare) duplicate-hit path.
+const messageByEventKey = new Map<string, CustomChatEvent>()
+// Cap on how many entries we keep in the dedup TTL map before forcing GC.
+const RECENT_EVENT_KEYS_GC_THRESHOLD = 512
 const renderQueue: CustomChatEvent[] = []
 let visibleMessages: CustomChatEvent[] = []
 const rowHeights = new Map<string, number>()
@@ -193,14 +207,31 @@ function eventKey(event: Pick<CustomChatEvent, 'kind' | 'uid' | 'text'>): string
   return `${event.kind}:${event.uid ?? ''}:${compactText(event.text).slice(0, 80)}`
 }
 
+function eventKeyOf(message: CustomChatEvent): string {
+  let key = eventKeyByMessage.get(message)
+  if (key === undefined) {
+    key = eventKey(message)
+    eventKeyByMessage.set(message, key)
+  }
+  return key
+}
+
 function messageKey(event: Pick<CustomChatEvent, 'source' | 'id'>): string {
   return `${event.source}:${event.id}`
 }
 
-function rememberEvent(event: Pick<CustomChatEvent, 'kind' | 'uid' | 'text'>): boolean {
-  const now = Date.now()
+function gcRecentEventKeys(now: number): void {
   for (const [key, ts] of recentEventKeys) {
     if (now - ts > 9000) recentEventKeys.delete(key)
+  }
+}
+
+function rememberEvent(event: Pick<CustomChatEvent, 'kind' | 'uid' | 'text'>): boolean {
+  const now = Date.now()
+  // Bound the map: only sweep when it grows past the threshold instead of
+  // iterating the whole map on every event.
+  if (recentEventKeys.size > RECENT_EVENT_KEYS_GC_THRESHOLD) {
+    gcRecentEventKeys(now)
   }
   const key = eventKey(event)
   if (recentEventKeys.has(key)) return false
@@ -210,10 +241,9 @@ function rememberEvent(event: Pick<CustomChatEvent, 'kind' | 'uid' | 'text'>): b
 
 function messageIndexByEvent(event: Pick<CustomChatEvent, 'kind' | 'uid' | 'text'>): number {
   const key = eventKey(event)
-  for (let index = messages.length - 1; index >= 0; index--) {
-    if (eventKey(messages[index]) === key) return index
-  }
-  return -1
+  const existing = messageByEventKey.get(key)
+  if (!existing) return -1
+  return messages.indexOf(existing)
 }
 
 function chooseBetterName(current: string, incoming: string): string {
@@ -301,19 +331,31 @@ function replaceMessage(index: number, next: CustomChatEvent): void {
   if (!previous) return
   const prevKey = messageKey(previous)
   const nextKey = messageKey(next)
+  const prevEventKey = eventKeyOf(previous)
+  const nextEventKey = eventKey(next)
+  eventKeyByMessage.set(next, nextEventKey)
   messages[index] = next
   if (prevKey !== nextKey) {
     messageKeys.delete(prevKey)
     rowHeights.delete(prevKey)
     messageKeys.add(nextKey)
   }
+  if (messageByEventKey.get(prevEventKey) === previous) {
+    messageByEventKey.delete(prevEventKey)
+  }
+  messageByEventKey.set(nextEventKey, next)
   scheduleRerenderMessages()
 }
 
 function recordEventStats(event: CustomChatEvent): void {
   const now = Date.now()
   eventTicks.push(now)
-  while (eventTicks.length > 0 && now - eventTicks[0] > 1000) eventTicks.shift()
+  // Find the first tick still inside the 1s window and drop everything before
+  // it in a single splice, instead of shifting one by one (O(n) per shift on
+  // each event during chat waves).
+  let dropCount = 0
+  while (dropCount < eventTicks.length && now - eventTicks[dropCount] > 1000) dropCount++
+  if (dropCount > 0) eventTicks.splice(0, dropCount)
   sourceCounts[event.source]++
 }
 
@@ -608,6 +650,7 @@ function wsStatusLabel(status: CustomChatWsStatus): string {
 
 function updateWsStatus(status: CustomChatWsStatus): void {
   currentWsStatus = status
+  syncNativeObserverWithWsStatus()
   if (!wsStatusEl) return
   wsStatusEl.textContent = wsStatusLabel(status)
   wsStatusEl.dataset.status =
@@ -704,12 +747,19 @@ function scrollListByWheel(event: WheelEvent): void {
 }
 
 function pruneMessages(): void {
-  while (messages.length > MAX_MESSAGES) {
-    const removed = messages.shift()
-    if (removed) {
-      const key = messageKey(removed)
-      messageKeys.delete(key)
-      rowHeights.delete(key)
+  if (messages.length <= MAX_MESSAGES) {
+    updatePerfDebug()
+    return
+  }
+  const dropCount = messages.length - MAX_MESSAGES
+  const removed = messages.splice(0, dropCount)
+  for (const message of removed) {
+    const key = messageKey(message)
+    messageKeys.delete(key)
+    rowHeights.delete(key)
+    const ek = eventKeyByMessage.get(message)
+    if (ek !== undefined && messageByEventKey.get(ek) === message) {
+      messageByEventKey.delete(ek)
     }
   }
   updatePerfDebug()
@@ -968,6 +1018,7 @@ function scrollToVirtualIndex(index: number): void {
 function clearMessages(): void {
   messages.length = 0
   messageKeys.clear()
+  messageByEventKey.clear()
   renderQueue.length = 0
   visibleMessages = []
   rowHeights.clear()
@@ -1276,11 +1327,19 @@ function createRoot(): HTMLElement {
   searchInput.placeholder = '搜索 user:名 kind:gift -词'
   searchInput.setAttribute('aria-label', '搜索直播聊天消息')
   searchInput.value = searchQuery
+  // Debounce keystrokes — every input event would otherwise re-filter all 220
+  // messages and rebuild the visible list. ~120ms is the sweet spot between
+  // perceived snappiness and not running the filter pass per character.
+  let searchInputTimer: ReturnType<typeof setTimeout> | null = null
   addRootEventListener(searchInput, 'input', () => {
-    searchQuery = searchInput?.value ?? ''
-    unread = 0
-    scheduleRerenderMessages({ refreshFrozenSnapshot: true })
-    updateUnread()
+    if (searchInputTimer !== null) clearTimeout(searchInputTimer)
+    searchInputTimer = setTimeout(() => {
+      searchInputTimer = null
+      searchQuery = searchInput?.value ?? ''
+      unread = 0
+      scheduleRerenderMessages({ refreshFrozenSnapshot: true })
+      updateUnread()
+    }, 120)
   })
 
   const clearBtn = makeButton('lc-chat-pill', '清屏', '清空自定义评论区', clearMessages)
@@ -1431,6 +1490,8 @@ function mount(container: HTMLElement): void {
   ensureStyles()
   abortRootEventListeners()
   nativeEventObserver?.disconnect()
+  nativeEventObserverContainer = null
+  nativeEventObserverSuspended = false
   root?.remove()
   rootUsesFallbackHost = false
   fallbackHost?.remove()
@@ -1475,6 +1536,8 @@ function mountFallback(): void {
   abortRootEventListeners()
   nativeEventObserver?.disconnect()
   nativeEventObserver = null
+  nativeEventObserverContainer = null
+  nativeEventObserverSuspended = false
   pendingNativeNodes.clear()
   root?.remove()
   const host = ensureFallbackHost()
@@ -1498,6 +1561,8 @@ function scheduleFallbackMount(): void {
 
 function observeNativeEvents(container: HTMLElement): void {
   nativeEventObserver?.disconnect()
+  nativeEventObserverContainer = null
+  nativeEventObserverSuspended = false
   pendingNativeNodes.clear()
   nativeHealthSamples.length = 0
   nativeDomWarning = false
@@ -1561,7 +1626,26 @@ function observeNativeEvents(container: HTMLElement): void {
       }
     }
   })
-  nativeEventObserver.observe(container, { childList: true, subtree: true })
+  nativeEventObserverContainer = container
+  // Don't bind the observer if WS is already healthy — DOM is fallback only.
+  if (currentWsStatus === 'live') {
+    nativeEventObserverSuspended = true
+  } else {
+    nativeEventObserverSuspended = false
+    nativeEventObserver.observe(container, { childList: true, subtree: true })
+  }
+}
+
+function syncNativeObserverWithWsStatus(): void {
+  if (!nativeEventObserver || !nativeEventObserverContainer) return
+  const shouldSuspend = currentWsStatus === 'live'
+  if (shouldSuspend && !nativeEventObserverSuspended) {
+    nativeEventObserver.disconnect()
+    nativeEventObserverSuspended = true
+  } else if (!shouldSuspend && nativeEventObserverSuspended) {
+    nativeEventObserver.observe(nativeEventObserverContainer, { childList: true, subtree: true })
+    nativeEventObserverSuspended = false
+  }
 }
 
 function addDomMessage(ev: DanmakuEvent): void {
@@ -1597,8 +1681,11 @@ function addEvent(event: CustomChatEvent): void {
   if (!rememberEvent(event)) return
   hasClearedMessages = false
   recordEventStats(event)
+  const ek = eventKey(event)
+  eventKeyByMessage.set(event, ek)
   messages.push(event)
   messageKeys.add(key)
+  messageByEventKey.set(ek, event)
   pruneMessages()
   scheduleRender(event)
 }
@@ -1656,6 +1743,8 @@ export function stopCustomChatDom(): void {
   abortRootEventListeners()
   nativeEventObserver?.disconnect()
   nativeEventObserver = null
+  nativeEventObserverContainer = null
+  nativeEventObserverSuspended = false
   pendingNativeNodes.clear()
   if (nativeScanDebounceTimer !== null) {
     clearTimeout(nativeScanDebounceTimer)
@@ -1695,6 +1784,7 @@ export function stopCustomChatDom(): void {
   debugEl = null
   messages.length = 0
   messageKeys.clear()
+  messageByEventKey.clear()
   renderQueue.length = 0
   visibleMessages = []
   rowHeights.clear()

--- a/src/lib/custom-chat-render.ts
+++ b/src/lib/custom-chat-render.ts
@@ -9,7 +9,9 @@ export type CustomChatPriority = 'message' | 'identity' | 'lite' | 'card' | 'cri
 export type CustomChatBadgeType = 'medal' | 'guard' | 'admin' | 'rank' | 'ul' | 'honor' | 'price' | 'other'
 
 export function trimRenderQueue(queue: CustomChatEvent[]): void {
-  while (queue.length > CUSTOM_CHAT_MAX_RENDER_QUEUE) queue.shift()
+  if (queue.length > CUSTOM_CHAT_MAX_RENDER_QUEUE) {
+    queue.splice(0, queue.length - CUSTOM_CHAT_MAX_RENDER_QUEUE)
+  }
 }
 
 export function takeRenderBatch(queue: CustomChatEvent[]): CustomChatEvent[] {

--- a/src/lib/custom-chat-style.ts
+++ b/src/lib/custom-chat-style.ts
@@ -987,7 +987,13 @@ export function ensureCustomChatStyles({
     nextUserStyleEl.id = userStyleId
     document.head.appendChild(nextUserStyleEl)
   }
-  nextUserStyleEl.textContent = customCss
+  // Avoid clobbering textContent unless the CSS string actually changed —
+  // reassigning forces a full stylesheet recompute even when the value is
+  // identical, and this runs from a Preact `effect` that fires whenever any
+  // of its tracked signals tick.
+  if (nextUserStyleEl.textContent !== customCss) {
+    nextUserStyleEl.textContent = customCss
+  }
 
   return { styleEl: nextStyleEl, userStyleEl: nextUserStyleEl }
 }

--- a/src/lib/fetch-hijack.ts
+++ b/src/lib/fetch-hijack.ts
@@ -18,18 +18,24 @@ function applyTransforms(url: string, data: any): void {
 /** Patches Response consumption for specific Bilibili live API endpoints. */
 ;(() => {
   try {
-    const ResponseProto = unsafeWindow.Response.prototype
+    const ResponseProto = unsafeWindow.Response.prototype as Response & {
+      __chatterboxFetchHijackInstalled?: boolean
+    }
+    if (ResponseProto.__chatterboxFetchHijackInstalled) return
+    ResponseProto.__chatterboxFetchHijackInstalled = true
 
     const origJson = ResponseProto.json
     ResponseProto.json = async function (this: Response): Promise<unknown> {
       const data = await origJson.call(this)
       const url = this.url
-      if (url && data && typeof data === 'object') {
-        try {
-          applyTransforms(url, data)
-        } catch (err) {
-          console.error('[Chatterbox] fetch-hijack json transform failed:', err)
-        }
+      // Fast path: skip transform inspection unless the feature is enabled and
+      // the URL is one we care about. `applyTransforms` short-circuits too,
+      // but doing it here avoids the function call entirely.
+      if (!url || !shouldHijackUrl(url) || !data || typeof data !== 'object') return data
+      try {
+        applyTransforms(url, data)
+      } catch (err) {
+        console.error('[Chatterbox] fetch-hijack json transform failed:', err)
       }
       return data
     }

--- a/src/lib/gm-signal.ts
+++ b/src/lib/gm-signal.ts
@@ -3,9 +3,19 @@ import { effect, type Signal, signal } from '@preact/signals'
 import { GM_getValue, GM_setValue } from '$'
 
 const registry = new Map<string, Signal<unknown>>()
+// Optional per-signal validators used by `applyImportedSettings` to reject
+// imported values that don't match the in-memory shape. Without this guard, a
+// malicious or malformed backup could silently corrupt runtime state (e.g.
+// `msgSendInterval = "5"` -> `interval * 1000` = NaN).
+const validators = new Map<string, (val: unknown) => boolean>()
 const pendingWrites = new Map<string, ReturnType<typeof setTimeout>>()
 const lastPersistedValues = new Map<string, unknown>()
 const GM_PERSIST_DEBOUNCE_MS = 150
+
+export type GmSignalOptions<T> = {
+  /** Returns true when `val` is a valid replacement for this signal. */
+  validate?: (val: unknown) => val is T
+}
 
 function flushSignalValue(key: string, value: unknown): void {
   pendingWrites.delete(key)
@@ -24,7 +34,13 @@ function schedulePersist(key: string, value: unknown): void {
   )
 }
 
-function flushPendingWrites(): void {
+/**
+ * Force-persist any signal writes that are still inside the debounce window.
+ * Wired up to `beforeunload`/`pagehide`/`visibilitychange=hidden` so a tab
+ * closing or backgrounding doesn't drop the user's most recent settings
+ * change. Exported for unit tests.
+ */
+export function flushPendingWrites(): void {
   for (const [key, timer] of pendingWrites) {
     clearTimeout(timer)
     const current = registry.get(key)
@@ -33,7 +49,16 @@ function flushPendingWrites(): void {
 }
 
 if (typeof window !== 'undefined') {
+  // `beforeunload` is unreliable on mobile browsers and back-forward cache; use
+  // `pagehide` and `visibilitychange` to flush whenever the page is being
+  // backgrounded or torn down.
   window.addEventListener('beforeunload', flushPendingWrites)
+  window.addEventListener('pagehide', flushPendingWrites)
+  if (typeof document !== 'undefined') {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') flushPendingWrites()
+    })
+  }
 }
 
 /**
@@ -41,11 +66,12 @@ if (typeof window !== 'undefined') {
  * under the given key. The signal is registered so that applyImportedSettings
  * can update it in-memory without requiring a page refresh.
  */
-export function gmSignal<T>(key: string, defaultValue: T) {
+export function gmSignal<T>(key: string, defaultValue: T, options?: GmSignalOptions<T>) {
   const initialValue = GM_getValue(key, defaultValue)
   const s = signal<T>(initialValue)
   registry.set(key, s as Signal<unknown>)
   lastPersistedValues.set(key, initialValue)
+  if (options?.validate) validators.set(key, options.validate)
   let isFirstRun = true
   effect(() => {
     const nextValue = s.value
@@ -60,13 +86,36 @@ export function gmSignal<T>(key: string, defaultValue: T) {
 }
 
 /**
+ * Returns true if the value passes the registered validator for this key, or
+ * if no validator is registered (back-compat for keys that haven't been
+ * annotated yet — they fall back to a coarse typeof check against the live
+ * signal value).
+ */
+export function isValidImportedValue(key: string, val: unknown): boolean {
+  const validator = validators.get(key)
+  if (validator) return validator(val)
+  const s = registry.get(key)
+  if (!s) return false
+  const current = s.value
+  if (val === null || current === null) return val === null && current === null
+  if (Array.isArray(current)) return Array.isArray(val)
+  return typeof val === typeof current
+}
+
+/**
  * Applies a record of imported settings to both GM storage and the live
  * in-memory signals, so changes take effect immediately without a page refresh.
- * Keys not present in the registry are silently ignored.
+ * Keys not present in the registry, or whose value fails validation, are
+ * silently ignored. Returns the count of keys actually applied.
  */
-export function applyImportedSettings(data: Record<string, unknown>): void {
+export function applyImportedSettings(data: Record<string, unknown>): number {
+  let applied = 0
   for (const [key, val] of Object.entries(data)) {
     const s = registry.get(key)
-    if (s) (s as Signal<unknown>).value = val
+    if (!s) continue
+    if (!isValidImportedValue(key, val)) continue
+    ;(s as Signal<unknown>).value = val
+    applied++
   }
+  return applied
 }

--- a/src/lib/guard-room-sync.ts
+++ b/src/lib/guard-room-sync.ts
@@ -66,8 +66,35 @@ export interface LiveDeskHeartbeatInput {
   riskLevel: RiskEventLevel
 }
 
-function normalizeGuardRoomEndpoint(endpoint: string): string {
-  return endpoint.trim().replace(/\/+$/, '')
+/**
+ * Returns a normalized endpoint (trailing slashes stripped) only if it's a
+ * usable URL. Rejects:
+ *  - non-http(s) schemes (e.g. `javascript:`, `file:`, `data:`)
+ *  - `http://` for any host other than localhost / loopback
+ *
+ * The watchlist payload includes the user's medal/follow list and the sync
+ * key, so we don't want a typo in settings to send those to a plaintext or
+ * unexpected origin.
+ */
+export function normalizeGuardRoomEndpoint(endpoint: string): string {
+  const trimmed = endpoint.trim().replace(/\/+$/, '')
+  if (!trimmed) return ''
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return ''
+  }
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return ''
+  if (parsed.protocol === 'http:') {
+    const host = parsed.hostname
+    // IPv6 hostnames come back wrapped in `[…]`, e.g. "[::1]" — strip
+    // brackets before comparison.
+    const bare = host.startsWith('[') && host.endsWith(']') ? host.slice(1, -1) : host
+    const isLoopback = bare === 'localhost' || bare === '127.0.0.1' || bare === '::1'
+    if (!isLoopback) return ''
+  }
+  return trimmed
 }
 
 export function classifyRiskEvent(

--- a/src/lib/live-ws-source.ts
+++ b/src/lib/live-ws-source.ts
@@ -46,6 +46,51 @@ let reconnectAttempt = 0
 let connectionSerial = 0
 let lastWsCloseDetail = ''
 const recentDanmaku = new Map<string, number>()
+// Hard cap so a misbehaving feed can't grow this map forever between cleanups.
+const RECENT_DANMAKU_MAX = 500
+// Use a NUL separator that can't appear in `uid` (digits) or chat `text` (Bilibili
+// strips control chars). Avoids `${uid}:${text}` collisions like
+// `uid="1", text="2:hi"` matching `uid="1:2", text="hi"`.
+const RECENT_DANMAKU_KEY_SEP = '\x00'
+
+// Exported for unit-test reach so we can verify the key shape doesn't
+// collide on values that contain the legacy `:` separator.
+export function recentKey(text: string, uid: string | null): string {
+  return `${uid ?? ''}${RECENT_DANMAKU_KEY_SEP}${text}`
+}
+
+/**
+ * Parses the value of the DedeUserID cookie into a numeric Bilibili LiveWS
+ * `uid` field. Bilibili expects a number. We fall back to anonymous (`0`) if:
+ *  - the cookie is missing/empty
+ *  - the value is not a finite integer
+ *  - the value is negative
+ *  - the value exceeds `Number.MAX_SAFE_INTEGER` (forward-compat against
+ *    future UID growth — sending a precision-lost number would be silently
+ *    wrong)
+ */
+export function parseAuthUid(uidCookie: string | null | undefined): number {
+  if (!uidCookie) return 0
+  const parsed = Number(uidCookie)
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return 0
+  return parsed
+}
+
+const RECONNECT_BASE_MS = 3000
+const RECONNECT_STEP_MS = 2000
+const RECONNECT_CAP_MS = 30_000
+const RECONNECT_JITTER_RATIO = 0.25
+
+/**
+ * Computes the next reconnect delay with capped linear backoff plus 0–25%
+ * jitter. The jitter prevents multiple Chatterbox tabs from reconnecting in
+ * lockstep against Bilibili's WS endpoints.
+ */
+export function computeReconnectDelay(attempt: number, random: () => number = Math.random): number {
+  const baseDelay = Math.min(RECONNECT_CAP_MS, RECONNECT_BASE_MS + attempt * RECONNECT_STEP_MS)
+  const jitter = Math.floor(random() * baseDelay * RECONNECT_JITTER_RATIO)
+  return baseDelay + jitter
+}
 const STARTUP_FAILURE_LOG_INTERVAL = 60_000
 
 function asRecord(value: unknown): UnknownRecord {
@@ -72,21 +117,38 @@ function avatarUrl(uid: string | null): string | undefined {
   return uid ? `${BASE_URL.BILIBILI_AVATAR}/${uid}?size=96` : undefined
 }
 
+// Counter so we sweep at most once every N reads. Amortizes the linear scan
+// to O(1) per call while preserving TTL semantics: a stale key won't survive
+// indefinitely, just up to (sweep interval) extra reads.
+let recentSweepCounter = 0
+const RECENT_SWEEP_INTERVAL = 32
+
 function cleanupRecent(): void {
+  recentSweepCounter++
+  // Always sweep when we're past the size cap; otherwise sweep periodically.
+  if (recentDanmaku.size <= RECENT_DANMAKU_MAX && recentSweepCounter < RECENT_SWEEP_INTERVAL) return
+  recentSweepCounter = 0
   const now = Date.now()
   for (const [key, ts] of recentDanmaku) {
     if (now - ts > 8000) recentDanmaku.delete(key)
+  }
+  // Best-effort: if expiry alone didn't drop us below the cap (e.g. a very
+  // chatty room with sub-8s churn), drop the oldest entries by insertion order.
+  while (recentDanmaku.size > RECENT_DANMAKU_MAX) {
+    const oldest = recentDanmaku.keys().next().value
+    if (oldest === undefined) break
+    recentDanmaku.delete(oldest)
   }
 }
 
 export function hasRecentWsDanmaku(text: string, uid: string | null): boolean {
   cleanupRecent()
-  return recentDanmaku.has(`${uid ?? ''}:${text}`)
+  return recentDanmaku.has(recentKey(text, uid))
 }
 
 function rememberWsDanmaku(text: string, uid: string | null): void {
   cleanupRecent()
-  recentDanmaku.set(`${uid ?? ''}:${text}`, Date.now())
+  recentDanmaku.set(recentKey(text, uid), Date.now())
 }
 
 function eventId(_cmd: string, data: UnknownRecord, fallback: string): string {
@@ -374,7 +436,7 @@ async function connect(): Promise<void> {
 
     const address = info.addresses[addressIndex % info.addresses.length]
     addressIndex += 1
-    const uid = Number(getDedeUid() ?? 0) || 0
+    const uid = parseAuthUid(getDedeUid())
     const buvid = getBuvid()
     const authBody: Record<string, unknown> = {
       uid,
@@ -413,7 +475,7 @@ async function connect(): Promise<void> {
       if (!started || liveConnection !== live) return
       const suffix = lastWsCloseDetail ? ` (${lastWsCloseDetail})` : ''
       appendStartupFailure(live.live ? `connection closed${suffix}` : `closed before room entered${suffix}`)
-      const delay = Math.min(30_000, 3000 + reconnectAttempt * 2000)
+      const delay = computeReconnectDelay(reconnectAttempt)
       reconnectAttempt += 1
       reconnectTimer = setTimeout(() => void connect(), delay)
     })

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -75,9 +75,11 @@ export function durationFromString(text: string): string | null {
   return `${formatDuration((end - Date.now()) / 1000)}（到 ${dateMatch[1]}）`
 }
 
-export function durationFromData(data: unknown): string | null {
+export function durationFromData(data: unknown, seen: WeakSet<object> = new WeakSet()): string | null {
   if (typeof data === 'string') return durationFromString(data)
   if (typeof data !== 'object' || data === null) return null
+  if (seen.has(data)) return null
+  seen.add(data)
 
   for (const [key, value] of Object.entries(data)) {
     const lowerKey = key.toLowerCase()
@@ -106,7 +108,7 @@ export function durationFromData(data: unknown): string | null {
         if (ms > Date.now()) return `${formatDuration((ms - Date.now()) / 1000)}（到 ${new Date(ms).toLocaleString()}）`
       }
     } else {
-      const nested = durationFromData(value)
+      const nested = durationFromData(value, seen)
       if (nested) return nested
     }
   }
@@ -120,17 +122,28 @@ export function describeRestrictionDuration(error: string | undefined, data: unk
 
 export function scanRestrictionSignals(data: unknown, source: string): RestrictionSignal[] {
   const signals: RestrictionSignal[] = []
-  scanNode(data, source, signals)
+  scanNode(data, source, signals, '', new WeakSet<object>())
   return signals
 }
 
-function scanNode(data: unknown, source: string, signals: RestrictionSignal[], path = ''): void {
+function scanNode(
+  data: unknown,
+  source: string,
+  signals: RestrictionSignal[],
+  path: string,
+  seen: WeakSet<object>
+): void {
   if (typeof data === 'string') {
     const kind = classifyText(data)
     if (kind) signals.push({ kind, message: data, duration: describeRestrictionDuration(data, null), source })
     return
   }
   if (typeof data !== 'object' || data === null) return
+  // Guard against cyclic JSON (the fetch-hijack runs before this and could in
+  // principle hand back a mutated object with a back-reference) so we don't
+  // blow the stack.
+  if (seen.has(data)) return
+  seen.add(data)
 
   for (const [key, value] of Object.entries(data)) {
     const lowerKey = key.toLowerCase()
@@ -157,7 +170,7 @@ function scanNode(data: unknown, source: string, signals: RestrictionSignal[], p
         })
       }
     }
-    scanNode(value, source, signals, currentPath)
+    scanNode(value, source, signals, currentPath, seen)
   }
 }
 

--- a/src/lib/remote-keywords-sanitize.ts
+++ b/src/lib/remote-keywords-sanitize.ts
@@ -1,0 +1,60 @@
+// Sanitizer for the remote-keyword JSON fetched from `workers.vrp.moe`. The
+// remote endpoint is trusted only as far as the network — a compromised CDN
+// could otherwise inject arbitrary maps that flow into `applyReplacements`
+// (and thus into outgoing danmaku) or balloon GM storage.
+//
+// Hard caps and per-entry typeof checks keep the output well-formed.
+
+export interface RemoteKeywords {
+  global?: { keywords?: Record<string, string> }
+  rooms?: Array<{ room: string; keywords?: Record<string, string> }>
+}
+
+export const REMOTE_KEYWORDS_MAX_GLOBAL = 1000
+export const REMOTE_KEYWORDS_MAX_PER_ROOM = 500
+export const REMOTE_KEYWORDS_MAX_ROOMS = 200
+export const REMOTE_KEYWORDS_MAX_KEY_LEN = 200
+export const REMOTE_KEYWORDS_MAX_VALUE_LEN = 200
+
+export function sanitizeKeywordsRecord(input: unknown, maxEntries: number): Record<string, string> {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return {}
+  const out: Record<string, string> = {}
+  let count = 0
+  for (const [from, to] of Object.entries(input as Record<string, unknown>)) {
+    if (count >= maxEntries) break
+    if (typeof from !== 'string' || typeof to !== 'string') continue
+    if (from.length === 0 || from.length > REMOTE_KEYWORDS_MAX_KEY_LEN) continue
+    if (to.length > REMOTE_KEYWORDS_MAX_VALUE_LEN) continue
+    out[from] = to
+    count++
+  }
+  return out
+}
+
+export function sanitizeRemoteKeywords(input: unknown): RemoteKeywords {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) return {}
+  const obj = input as Record<string, unknown>
+  const result: RemoteKeywords = {}
+  const globalSection = obj.global
+  if (typeof globalSection === 'object' && globalSection !== null && !Array.isArray(globalSection)) {
+    result.global = {
+      keywords: sanitizeKeywordsRecord((globalSection as Record<string, unknown>).keywords, REMOTE_KEYWORDS_MAX_GLOBAL),
+    }
+  }
+  if (Array.isArray(obj.rooms)) {
+    const rooms: Array<{ room: string; keywords?: Record<string, string> }> = []
+    for (const entry of obj.rooms) {
+      if (rooms.length >= REMOTE_KEYWORDS_MAX_ROOMS) break
+      if (typeof entry !== 'object' || entry === null) continue
+      const roomEntry = entry as Record<string, unknown>
+      const roomId = typeof roomEntry.room === 'string' ? roomEntry.room : String(roomEntry.room ?? '')
+      if (!roomId) continue
+      rooms.push({
+        room: roomId,
+        keywords: sanitizeKeywordsRecord(roomEntry.keywords, REMOTE_KEYWORDS_MAX_PER_ROOM),
+      })
+    }
+    result.rooms = rooms
+  }
+  return result
+}

--- a/src/lib/replacement.ts
+++ b/src/lib/replacement.ts
@@ -1,10 +1,19 @@
+import { effect } from '@preact/signals'
+
 import { cachedRoomId, localGlobalRules, localRoomRules, remoteKeywords, replacementMap } from './store'
 
 /**
  * Builds the replacement map from remote and local rules.
  * Priority: remote global < remote room < local global < local room.
+ *
+ * Skips the write when `cachedRoomId` is mid-resolution (null) so we don't
+ * clobber a previously-correct map with one missing the room-specific rules.
+ * The effect below re-runs when the room id resolves.
  */
 export function buildReplacementMap(): void {
+  const rid = cachedRoomId.value
+  if (rid === null && replacementMap.value !== null) return
+
   const map = new Map<string, string>()
 
   const rk = remoteKeywords.value
@@ -14,7 +23,6 @@ export function buildReplacementMap(): void {
       if (from) map.set(from, to)
     }
 
-    const rid = cachedRoomId.value
     if (rid !== null) {
       const roomData = rk.rooms?.find(r => String(r.room) === String(rid))
       const roomKeywords = roomData?.keywords ?? {}
@@ -28,7 +36,6 @@ export function buildReplacementMap(): void {
     if (rule.from) map.set(rule.from, rule.to ?? '')
   }
 
-  const rid = cachedRoomId.value
   if (rid !== null) {
     const roomRules = localRoomRules.value[String(rid)] ?? []
     for (const rule of roomRules) {
@@ -38,6 +45,17 @@ export function buildReplacementMap(): void {
 
   replacementMap.value = map
 }
+
+// Auto-rebuild whenever the cached room id, remote keywords, or local rules
+// change. This makes manual `buildReplacementMap()` calls idempotent and
+// guarantees the map tracks the active room across SPA navigation.
+effect(() => {
+  cachedRoomId.value
+  remoteKeywords.value
+  localGlobalRules.value
+  localRoomRules.value
+  buildReplacementMap()
+})
 
 /**
  * Applies all replacement rules to the given text using the cached map.

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -148,12 +148,21 @@ export function splitTextSmart(
 }
 
 /**
- * Extracts the room number from a Bilibili live room URL.
+ * Extracts the room number from a Bilibili live room URL. Returns undefined
+ * for non-live hosts or paths that don't end in a numeric room id (e.g.
+ * `/p/eden/area-tags/12345` should not be treated as room 12345).
+ *
+ * Recognized shapes:
+ *   live.bilibili.com/12345
+ *   live.bilibili.com/blanc/12345
+ *   live.bilibili.com/h5/12345
+ * with optional trailing slash, query string, or hash.
  */
 export function extractRoomNumber(url: string): string | undefined {
   const urlObj = new URL(url)
-  const pathSegments = urlObj.pathname.split('/').filter(segment => segment !== '')
-  return pathSegments.find(segment => Number.isInteger(Number(segment)))
+  if (urlObj.hostname !== 'live.bilibili.com') return undefined
+  const match = urlObj.pathname.match(/^\/(?:blanc\/|h5\/)?(\d+)\/?$/)
+  return match ? match[1] : undefined
 }
 
 /**

--- a/src/lib/wbi.ts
+++ b/src/lib/wbi.ts
@@ -18,6 +18,13 @@ function extractWbiKeys(data: { data?: { wbi_img?: { img_url?: string; sub_url?:
 }
 
 ;(() => {
+  // Sentinel: avoid double-wrapping the prototype if this module is re-imported
+  // (e.g. when the userscript runs in both the top frame and a nested iframe).
+  const sentinel = '__chatterboxWbiHijackInstalled' as const
+  const proto = XMLHttpRequest.prototype as XMLHttpRequest & { [sentinel]?: boolean }
+  if (proto[sentinel]) return
+  proto[sentinel] = true
+
   const originalOpen = XMLHttpRequest.prototype.open
   const originalSend = XMLHttpRequest.prototype.send
 

--- a/tests/ai-evasion-empty.test.ts
+++ b/tests/ai-evasion-empty.test.ts
@@ -1,0 +1,42 @@
+// Regression test for the M-fix: AI-evasion previously enqueued any value
+// returned by `replaceSensitiveWords`, including the empty string when the
+// detected sensitive words consumed the whole message.
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('$', () => ({
+  GM_deleteValue: () => {},
+  GM_getValue: <T>(_key: string, defaultValue: T): T => defaultValue,
+  GM_info: { script: { version: 'test' } },
+  GM_setValue: () => {},
+}))
+
+const { isEvadedMessageSendable, replaceSensitiveWords, processText } = await import('../src/lib/ai-evasion')
+
+describe('AI-evasion empty-string guard', () => {
+  test('isEvadedMessageSendable rejects empty/whitespace-only strings', () => {
+    expect(isEvadedMessageSendable('')).toBe(false)
+    expect(isEvadedMessageSendable('   ')).toBe(false)
+    expect(isEvadedMessageSendable('\t\n  ')).toBe(false)
+  })
+
+  test('isEvadedMessageSendable accepts strings with at least one non-ws char', () => {
+    expect(isEvadedMessageSendable('a')).toBe(true)
+    expect(isEvadedMessageSendable('  hi  ')).toBe(true)
+    // After insertInvisibleChars: contains soft-hyphens + visible chars.
+    expect(isEvadedMessageSendable(processText('hello'))).toBe(true)
+  })
+
+  test('replaceSensitiveWords ignores empty entries instead of expanding to bookend matches', () => {
+    // Pre-fix: ''.split('') returned ['', 'a', 'b', 'c', ''] then joined
+    // back, which could mangle the message. The guard now skips empty words.
+    expect(replaceSensitiveWords('hello', [''])).toBe('hello')
+    expect(replaceSensitiveWords('hello', ['', 'l'])).toContain(processText('l'))
+  })
+
+  test('replaces matched words with insert-invisible-char form', () => {
+    const result = replaceSensitiveWords('say hello to hello', ['hello'])
+    expect(result.includes('hello')).toBe(false)
+    expect(result.split(processText('hello')).length - 1).toBe(2)
+  })
+})

--- a/tests/api-concurrency.test.ts
+++ b/tests/api-concurrency.test.ts
@@ -1,0 +1,55 @@
+// Regression test for the C3 audit fix: anchor lookups previously ran
+// sequentially with no per-request timeout, so a slow Bilibili response could
+// stall the settings UI indefinitely. The fix runs them through
+// `mapWithConcurrency` (capped at 6 in the call site) and wraps each fetch
+// with an AbortController timeout.
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('$', () => ({
+  GM_deleteValue: () => {},
+  GM_getValue: <T>(_key: string, defaultValue: T): T => defaultValue,
+  GM_info: { script: { version: 'test' } },
+  GM_setValue: () => {},
+  unsafeWindow: globalThis,
+}))
+
+const { mapWithConcurrency } = await import('../src/lib/api')
+
+describe('mapWithConcurrency', () => {
+  test('processes every item exactly once and preserves order', async () => {
+    const items = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const seen: number[] = []
+    const results = await mapWithConcurrency(items, 3, async n => {
+      seen.push(n)
+      await new Promise(r => setTimeout(r, n))
+      return n * 10
+    })
+    expect(results).toEqual([10, 20, 30, 40, 50, 60, 70, 80, 90, 100])
+    expect(seen.sort((a, b) => a - b)).toEqual(items)
+  })
+
+  test('honors the concurrency cap', async () => {
+    let inFlight = 0
+    let peak = 0
+    const items = Array.from({ length: 20 }, (_, i) => i)
+    await mapWithConcurrency(items, 4, async () => {
+      inFlight++
+      peak = Math.max(peak, inFlight)
+      await new Promise(r => setTimeout(r, 5))
+      inFlight--
+      return null
+    })
+    expect(peak).toBeLessThanOrEqual(4)
+    expect(peak).toBeGreaterThan(0)
+  })
+
+  test('handles empty input', async () => {
+    expect(await mapWithConcurrency([], 5, async () => null)).toEqual([])
+  })
+
+  test('limit greater than item count uses item count as worker pool', async () => {
+    const result = await mapWithConcurrency([1, 2, 3], 100, async n => n + 1)
+    expect(result).toEqual([2, 3, 4])
+  })
+})

--- a/tests/backup-import-validate.test.ts
+++ b/tests/backup-import-validate.test.ts
@@ -1,0 +1,100 @@
+// Regression tests for the H-sec audit fix: `importSettings` previously wrote
+// any value type for whitelisted keys, so a malformed backup could corrupt
+// runtime state (e.g. msgSendInterval = "5" -> NaN * 1000) and the
+// __version field was never enforced.
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const gmStore = new Map<string, unknown>()
+
+mock.module('$', () => ({
+  GM_deleteValue: (key: string) => {
+    gmStore.delete(key)
+  },
+  GM_getValue: <T>(key: string, defaultValue: T): T => (gmStore.has(key) ? (gmStore.get(key) as T) : defaultValue),
+  GM_setValue: (key: string, value: unknown) => {
+    gmStore.set(key, value)
+  },
+}))
+
+const { importSettings } = await import('../src/lib/backup')
+const { isValidImportedValue } = await import('../src/lib/gm-signal')
+const { msgSendInterval, randomColor, msgTemplates } = await import('../src/lib/store')
+
+describe('isValidImportedValue', () => {
+  test('accepts values matching the in-memory typeof', () => {
+    expect(isValidImportedValue('msgSendInterval', 5)).toBe(true)
+    expect(isValidImportedValue('randomColor', true)).toBe(true)
+    expect(isValidImportedValue('MsgTemplates', ['hello'])).toBe(true)
+  })
+
+  test('rejects mismatched primitives', () => {
+    expect(isValidImportedValue('msgSendInterval', '5')).toBe(false)
+    expect(isValidImportedValue('msgSendInterval', null)).toBe(false)
+    expect(isValidImportedValue('randomColor', 'true')).toBe(false)
+  })
+
+  test('distinguishes arrays from objects', () => {
+    expect(isValidImportedValue('MsgTemplates', { 0: 'a' })).toBe(false)
+    expect(isValidImportedValue('MsgTemplates', null)).toBe(false)
+  })
+
+  test('returns false for unknown keys', () => {
+    expect(isValidImportedValue('not-a-real-key', 42)).toBe(false)
+  })
+})
+
+describe('importSettings', () => {
+  beforeEach(() => {
+    gmStore.clear()
+    msgSendInterval.value = 1
+    randomColor.value = false
+    msgTemplates.value = []
+  })
+
+  test('rejects backups with an unknown future __version', () => {
+    const json = JSON.stringify({ __version: 999, msgSendInterval: 7 })
+    const result = importSettings(json)
+    expect(result.ok).toBe(false)
+    expect(result.error).toContain('999')
+    expect(msgSendInterval.value).toBe(1)
+  })
+
+  test('drops keys whose imported value fails validation', () => {
+    const json = JSON.stringify({
+      __version: 1,
+      msgSendInterval: '5', // wrong type — should be ignored
+      randomColor: true, // valid — should apply
+    })
+    const result = importSettings(json)
+    expect(result.ok).toBe(true)
+    expect(result.count).toBe(1)
+    expect(msgSendInterval.value).toBe(1) // untouched
+    expect(randomColor.value).toBe(true)
+  })
+
+  test('accepts well-formed backups', () => {
+    const json = JSON.stringify({
+      __version: 1,
+      msgSendInterval: 7,
+      MsgTemplates: ['hello', 'world'],
+    })
+    const result = importSettings(json)
+    expect(result.ok).toBe(true)
+    expect(result.count).toBe(2)
+    expect(msgSendInterval.value).toBe(7)
+    expect(msgTemplates.value).toEqual(['hello', 'world'])
+  })
+
+  test('rejects malformed JSON', () => {
+    const result = importSettings('not json')
+    expect(result.ok).toBe(false)
+    expect(result.count).toBe(0)
+  })
+
+  test('rejects non-object roots', () => {
+    expect(importSettings('[]').ok).toBe(false)
+    expect(importSettings('null').ok).toBe(false)
+    expect(importSettings('"string"').ok).toBe(false)
+  })
+})

--- a/tests/custom-chat-render.test.ts
+++ b/tests/custom-chat-render.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from 'bun:test'
 
 import type { CustomChatEvent } from '../src/lib/custom-chat-events'
 
-import { customChatBadgeType, customChatPriority, shouldSuppressCustomChatEvent } from '../src/lib/custom-chat-render'
+import {
+  CUSTOM_CHAT_MAX_RENDER_QUEUE,
+  customChatBadgeType,
+  customChatPriority,
+  shouldSuppressCustomChatEvent,
+  trimRenderQueue,
+} from '../src/lib/custom-chat-render'
 
 const baseEvent: CustomChatEvent = {
   id: '1',
@@ -38,5 +44,34 @@ describe('custom chat render classification', () => {
     expect(customChatBadgeType('牌子 18')).toBe('medal')
     expect(customChatBadgeType('SC 30元')).toBe('price')
     expect(customChatBadgeType('0.1元')).toBe('price')
+  })
+})
+
+describe('trimRenderQueue (perf regression: was while-shift loop)', () => {
+  function makeEvents(n: number): CustomChatEvent[] {
+    return Array.from({ length: n }, (_, i) => ({ ...baseEvent, id: String(i) }))
+  }
+
+  test('no-op when under cap', () => {
+    const queue = makeEvents(10)
+    trimRenderQueue(queue)
+    expect(queue.length).toBe(10)
+  })
+
+  test('drops the oldest entries to leave exactly the cap', () => {
+    const queue = makeEvents(CUSTOM_CHAT_MAX_RENDER_QUEUE + 25)
+    const lastIdBefore = queue[queue.length - 1].id
+    trimRenderQueue(queue)
+    expect(queue.length).toBe(CUSTOM_CHAT_MAX_RENDER_QUEUE)
+    // Newest item is preserved at the tail.
+    expect(queue[queue.length - 1].id).toBe(lastIdBefore)
+    // First item is now the (old length - cap)th original.
+    expect(queue[0].id).toBe('25')
+  })
+
+  test('handles a queue exactly at the cap (boundary)', () => {
+    const queue = makeEvents(CUSTOM_CHAT_MAX_RENDER_QUEUE)
+    trimRenderQueue(queue)
+    expect(queue.length).toBe(CUSTOM_CHAT_MAX_RENDER_QUEUE)
   })
 })

--- a/tests/gm-signal.test.ts
+++ b/tests/gm-signal.test.ts
@@ -43,4 +43,55 @@ describe('gmSignal persistence', () => {
     await new Promise(resolve => setTimeout(resolve, 180))
     expect(getWritesForKey(key)).toEqual([{ key, value: 4 }])
   })
+
+  // Regression: M-fix. Pre-fix, only `beforeunload` was wired up. Mobile
+  // browsers and bfcache transitions don't fire beforeunload reliably, so
+  // pending writes were lost when the tab was backgrounded or closed. We
+  // verify the underlying `flushPendingWrites` (which all three listeners
+  // ultimately call) drains the debounce window synchronously.
+  test('flushPendingWrites synchronously persists outstanding writes', async () => {
+    const { flushPendingWrites } = await import('../src/lib/gm-signal')
+    const key = 'flush-test'
+    const value = gmSignal(key, 0)
+    value.value = 99
+    expect(getWritesForKey(key)).toHaveLength(0)
+    flushPendingWrites()
+    expect(getWritesForKey(key)).toEqual([{ key, value: 99 }])
+  })
+
+  test('the source wires pagehide and visibilitychange listeners (not just beforeunload)', async () => {
+    // Lock in the contract so a refactor that drops one of the events would
+    // fail this test instead of silently losing data on mobile bfcache.
+    const src = await Bun.file(`${import.meta.dir}/../src/lib/gm-signal.ts`).text()
+    expect(src).toContain('beforeunload')
+    expect(src).toContain('pagehide')
+    expect(src).toContain('visibilitychange')
+  })
+})
+
+describe('isValidImportedValue (gm-signal validator)', () => {
+  test('coarse typeof check passes for matching types and rejects mismatches', async () => {
+    const { isValidImportedValue } = await import('../src/lib/gm-signal')
+    gmSignal('typecheck-num', 5)
+    gmSignal('typecheck-bool', false)
+    gmSignal('typecheck-arr', [1, 2])
+
+    expect(isValidImportedValue('typecheck-num', 9)).toBe(true)
+    expect(isValidImportedValue('typecheck-num', '9')).toBe(false)
+    expect(isValidImportedValue('typecheck-bool', true)).toBe(true)
+    expect(isValidImportedValue('typecheck-bool', 1)).toBe(false)
+    expect(isValidImportedValue('typecheck-arr', [3])).toBe(true)
+    expect(isValidImportedValue('typecheck-arr', { 0: 1 })).toBe(false)
+    expect(isValidImportedValue('not-registered', 0)).toBe(false)
+  })
+
+  test('custom validate option overrides the typeof check', async () => {
+    const { isValidImportedValue } = await import('../src/lib/gm-signal')
+    gmSignal('strict-positive', 5, {
+      validate: (val): val is number => typeof val === 'number' && val > 0,
+    })
+    expect(isValidImportedValue('strict-positive', 7)).toBe(true)
+    expect(isValidImportedValue('strict-positive', -1)).toBe(false)
+    expect(isValidImportedValue('strict-positive', 'x')).toBe(false)
+  })
 })

--- a/tests/guard-room-endpoint.test.ts
+++ b/tests/guard-room-endpoint.test.ts
@@ -1,0 +1,54 @@
+// Regression tests for the H-sec audit fix: the Guard Room sync endpoint is
+// user-typed and previously normalized only with `trim().replace(/\/+$/, '')`,
+// so a typo or attacker-controlled value would exfiltrate the watchlist + sync
+// key over plaintext or to a non-http(s) destination.
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('$', () => ({
+  GM_deleteValue: () => {},
+  GM_getValue: <T>(_key: string, defaultValue: T): T => defaultValue,
+  GM_info: { script: { version: 'test' } },
+  GM_setValue: () => {},
+}))
+
+const { normalizeGuardRoomEndpoint } = await import('../src/lib/guard-room-sync')
+
+describe('normalizeGuardRoomEndpoint', () => {
+  test('accepts https endpoints and strips trailing slashes', () => {
+    expect(normalizeGuardRoomEndpoint('https://bilibili-guard-room.vercel.app')).toBe(
+      'https://bilibili-guard-room.vercel.app'
+    )
+    expect(normalizeGuardRoomEndpoint('https://bilibili-guard-room.vercel.app/')).toBe(
+      'https://bilibili-guard-room.vercel.app'
+    )
+    expect(normalizeGuardRoomEndpoint('  https://bilibili-guard-room.vercel.app///  ')).toBe(
+      'https://bilibili-guard-room.vercel.app'
+    )
+  })
+
+  test('accepts http only for loopback hosts', () => {
+    expect(normalizeGuardRoomEndpoint('http://localhost:3000')).toBe('http://localhost:3000')
+    expect(normalizeGuardRoomEndpoint('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080')
+    expect(normalizeGuardRoomEndpoint('http://[::1]:8080')).toBe('http://[::1]:8080')
+  })
+
+  test('rejects http for non-loopback hosts (would expose sync key + watchlist)', () => {
+    expect(normalizeGuardRoomEndpoint('http://attacker.example.com')).toBe('')
+    expect(normalizeGuardRoomEndpoint('http://bilibili-guard-room.vercel.app')).toBe('')
+  })
+
+  test('rejects non-http(s) schemes', () => {
+    expect(normalizeGuardRoomEndpoint('javascript:alert(1)')).toBe('')
+    expect(normalizeGuardRoomEndpoint('file:///etc/passwd')).toBe('')
+    expect(normalizeGuardRoomEndpoint('data:text/plain,leak')).toBe('')
+    expect(normalizeGuardRoomEndpoint('ws://example.com')).toBe('')
+  })
+
+  test('rejects unparseable input', () => {
+    expect(normalizeGuardRoomEndpoint('')).toBe('')
+    expect(normalizeGuardRoomEndpoint('   ')).toBe('')
+    expect(normalizeGuardRoomEndpoint('not a url')).toBe('')
+    expect(normalizeGuardRoomEndpoint('//missing-scheme.example.com')).toBe('')
+  })
+})

--- a/tests/moderation.test.ts
+++ b/tests/moderation.test.ts
@@ -39,4 +39,15 @@ describe('moderation', () => {
     expect(signals.map(signal => signal.kind)).toContain('muted')
     expect(signals.map(signal => signal.kind)).toContain('rate-limit')
   })
+
+  // Regression: H-logic audit fix. Cyclic input previously stack-overflowed.
+  test('does not stack-overflow on cyclic JSON', () => {
+    const cyclic: Record<string, unknown> = { silent: true }
+    cyclic.self = cyclic
+    cyclic.nested = { back: cyclic }
+
+    expect(() => scanRestrictionSignals(cyclic, 'unit')).not.toThrow()
+    const signals = scanRestrictionSignals(cyclic, 'unit')
+    expect(signals.some(signal => signal.kind === 'muted')).toBe(true)
+  })
 })

--- a/tests/recent-danmaku-key.test.ts
+++ b/tests/recent-danmaku-key.test.ts
@@ -1,0 +1,97 @@
+// Regression test for the M-fix: `recentDanmaku` previously keyed on
+// `${uid}:${text}` which collided for inputs whose uid or text contained `:`.
+// E.g. uid="1", text="2:hi" produced the same key as uid="1:2", text="hi".
+// The fix uses `\x00` as the separator (cannot appear in either field).
+
+import { describe, expect, mock, test } from 'bun:test'
+
+const gmStore = new Map<string, unknown>()
+
+mock.module('$', () => ({
+  GM_deleteValue: () => {},
+  GM_getValue: <T>(key: string, defaultValue: T): T => (gmStore.has(key) ? (gmStore.get(key) as T) : defaultValue),
+  GM_setValue: () => {},
+  GM_info: { script: { version: 'test' } },
+  unsafeWindow: globalThis,
+}))
+
+const { recentKey, parseAuthUid, computeReconnectDelay } = await import('../src/lib/live-ws-source')
+
+describe('computeReconnectDelay (H-logic: jitter + cap)', () => {
+  test('grows linearly with attempt count', () => {
+    const a = computeReconnectDelay(0, () => 0)
+    const b = computeReconnectDelay(1, () => 0)
+    const c = computeReconnectDelay(5, () => 0)
+    expect(a).toBe(3000)
+    expect(b).toBe(5000)
+    expect(c).toBe(13000)
+  })
+
+  test('caps the base at 30s', () => {
+    expect(computeReconnectDelay(100, () => 0)).toBe(30_000)
+    expect(computeReconnectDelay(1000, () => 0)).toBe(30_000)
+  })
+
+  test('adds jitter up to 25% of the base', () => {
+    expect(computeReconnectDelay(0, () => 0)).toBe(3000)
+    // random() = 0.999 → jitter ≈ floor(0.999 * 3000 * 0.25) = 749
+    expect(computeReconnectDelay(0, () => 0.999)).toBe(3749)
+  })
+
+  test('different attempts with the same random produce different delays', () => {
+    const x = computeReconnectDelay(2, () => 0.5)
+    const y = computeReconnectDelay(3, () => 0.5)
+    expect(y).toBeGreaterThan(x)
+  })
+})
+
+describe('parseAuthUid (C1: precision-safe Bilibili LiveWS uid parsing)', () => {
+  test('returns 0 for missing cookie', () => {
+    expect(parseAuthUid(undefined)).toBe(0)
+    expect(parseAuthUid(null)).toBe(0)
+    expect(parseAuthUid('')).toBe(0)
+  })
+
+  test('parses normal Bilibili uids', () => {
+    expect(parseAuthUid('12345678')).toBe(12345678)
+    expect(parseAuthUid('1')).toBe(1)
+  })
+
+  test('falls back to anonymous on non-numeric input', () => {
+    expect(parseAuthUid('not-a-number')).toBe(0)
+    expect(parseAuthUid('NaN')).toBe(0)
+    expect(parseAuthUid('1.5')).toBe(0)
+  })
+
+  test('falls back to anonymous on negative or out-of-range values', () => {
+    expect(parseAuthUid('-1')).toBe(0)
+    // Beyond Number.MAX_SAFE_INTEGER → fall back rather than send a
+    // precision-lost number.
+    expect(parseAuthUid('9007199254740993')).toBe(0)
+  })
+})
+
+describe('recentKey collision-resistance', () => {
+  test('uid and text with `:` characters produce distinct keys', () => {
+    const a = recentKey('2:hi', '1')
+    const b = recentKey('hi', '1:2')
+    expect(a).not.toBe(b)
+  })
+
+  test('null uid does not collide with the literal string "null"', () => {
+    const a = recentKey('hi', null)
+    const b = recentKey('hi', 'null')
+    expect(a).not.toBe(b)
+  })
+
+  test('different texts always produce different keys for the same uid', () => {
+    const a = recentKey('hello', '42')
+    const b = recentKey('world', '42')
+    expect(a).not.toBe(b)
+  })
+
+  test('separator is the NUL character that Bilibili strips from chat text', () => {
+    const k = recentKey('hi', '42')
+    expect(k.includes('\x00')).toBe(true)
+  })
+})

--- a/tests/remote-keywords-sanitize.test.ts
+++ b/tests/remote-keywords-sanitize.test.ts
@@ -1,0 +1,116 @@
+// Regression tests for the H-sec audit fix: `fetchRemoteKeywords` previously
+// stored whatever the CDN returned, with no schema validation. A compromised
+// CDN could inject huge maps or non-string values that propagate into
+// `applyReplacements` and outgoing danmaku.
+
+import { describe, expect, test } from 'bun:test'
+
+import {
+  REMOTE_KEYWORDS_MAX_GLOBAL,
+  REMOTE_KEYWORDS_MAX_PER_ROOM,
+  REMOTE_KEYWORDS_MAX_ROOMS,
+  REMOTE_KEYWORDS_MAX_VALUE_LEN,
+  sanitizeKeywordsRecord,
+  sanitizeRemoteKeywords,
+} from '../src/lib/remote-keywords-sanitize'
+
+describe('sanitizeKeywordsRecord', () => {
+  test('keeps well-formed string entries', () => {
+    expect(sanitizeKeywordsRecord({ foo: 'bar', baz: 'qux' }, 100)).toEqual({ foo: 'bar', baz: 'qux' })
+  })
+
+  test('drops non-string keys/values silently', () => {
+    expect(
+      sanitizeKeywordsRecord(
+        {
+          foo: 'ok',
+          bar: 42,
+          baz: null,
+          qux: { nested: 'no' },
+        },
+        100
+      )
+    ).toEqual({ foo: 'ok' })
+  })
+
+  test('rejects non-object inputs', () => {
+    expect(sanitizeKeywordsRecord(null, 100)).toEqual({})
+    expect(sanitizeKeywordsRecord('string', 100)).toEqual({})
+    expect(sanitizeKeywordsRecord([['foo', 'bar']], 100)).toEqual({})
+  })
+
+  test('caps entries at maxEntries', () => {
+    const huge: Record<string, string> = {}
+    for (let i = 0; i < 5; i++) huge[`k${i}`] = `v${i}`
+    expect(Object.keys(sanitizeKeywordsRecord(huge, 3))).toHaveLength(3)
+  })
+
+  test('drops over-long values', () => {
+    const oversize = 'x'.repeat(REMOTE_KEYWORDS_MAX_VALUE_LEN + 1)
+    expect(sanitizeKeywordsRecord({ ok: 'short', bad: oversize }, 100)).toEqual({ ok: 'short' })
+  })
+
+  test('drops empty keys', () => {
+    expect(sanitizeKeywordsRecord({ '': 'no-empty-key' }, 100)).toEqual({})
+  })
+})
+
+describe('sanitizeRemoteKeywords', () => {
+  test('passes through well-formed payloads', () => {
+    const input = {
+      global: { keywords: { hello: 'world' } },
+      rooms: [{ room: '101', keywords: { foo: 'bar' } }],
+    }
+    expect(sanitizeRemoteKeywords(input)).toEqual({
+      global: { keywords: { hello: 'world' } },
+      rooms: [{ room: '101', keywords: { foo: 'bar' } }],
+    })
+  })
+
+  test('returns empty object for non-object inputs', () => {
+    expect(sanitizeRemoteKeywords(null)).toEqual({})
+    expect(sanitizeRemoteKeywords('attack')).toEqual({})
+    expect(sanitizeRemoteKeywords([])).toEqual({})
+  })
+
+  test('caps the number of rooms', () => {
+    const rooms = Array.from({ length: REMOTE_KEYWORDS_MAX_ROOMS + 50 }, (_, i) => ({
+      room: String(i),
+      keywords: { foo: 'bar' },
+    }))
+    const out = sanitizeRemoteKeywords({ rooms })
+    expect(out.rooms?.length).toBe(REMOTE_KEYWORDS_MAX_ROOMS)
+  })
+
+  test('caps per-room and global rule counts', () => {
+    const tooManyGlobal: Record<string, string> = {}
+    for (let i = 0; i < REMOTE_KEYWORDS_MAX_GLOBAL + 50; i++) tooManyGlobal[`k${i}`] = `v${i}`
+    const tooManyRoom: Record<string, string> = {}
+    for (let i = 0; i < REMOTE_KEYWORDS_MAX_PER_ROOM + 50; i++) tooManyRoom[`k${i}`] = `v${i}`
+
+    const out = sanitizeRemoteKeywords({
+      global: { keywords: tooManyGlobal },
+      rooms: [{ room: '1', keywords: tooManyRoom }],
+    })
+    expect(Object.keys(out.global?.keywords ?? {})).toHaveLength(REMOTE_KEYWORDS_MAX_GLOBAL)
+    expect(Object.keys(out.rooms?.[0]?.keywords ?? {})).toHaveLength(REMOTE_KEYWORDS_MAX_PER_ROOM)
+  })
+
+  test('coerces numeric room ids to strings; drops empty room ids', () => {
+    const out = sanitizeRemoteKeywords({
+      rooms: [
+        { room: 101, keywords: { a: 'b' } },
+        { room: '', keywords: { x: 'y' } },
+        { room: null, keywords: { x: 'y' } },
+      ],
+    })
+    expect(out.rooms).toEqual([{ room: '101', keywords: { a: 'b' } }])
+  })
+
+  test('drops malformed room entries silently', () => {
+    const out = sanitizeRemoteKeywords({
+      rooms: [null, 'not an object', { room: '101', keywords: { foo: 'bar' } }],
+    })
+    expect(out.rooms).toEqual([{ room: '101', keywords: { foo: 'bar' } }])
+  })
+})

--- a/tests/replacement-reactive.test.ts
+++ b/tests/replacement-reactive.test.ts
@@ -1,0 +1,72 @@
+// Regression tests for the C4 audit fix: `buildReplacementMap` raced SPA
+// room navigation. The fix installs an `effect()` that auto-rebuilds when any
+// of cachedRoomId / remoteKeywords / local rules change, and skips writing
+// when cachedRoomId is mid-resolution (null) so it can't clobber a valid map
+// with one missing the room-specific rules.
+
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const gmStore = new Map<string, unknown>()
+
+mock.module('$', () => ({
+  GM_deleteValue: (key: string) => {
+    gmStore.delete(key)
+  },
+  GM_getValue: <T>(key: string, defaultValue: T): T => (gmStore.has(key) ? (gmStore.get(key) as T) : defaultValue),
+  GM_setValue: (key: string, value: unknown) => {
+    gmStore.set(key, value)
+  },
+}))
+
+const { applyReplacements } = await import('../src/lib/replacement')
+const { cachedRoomId, localGlobalRules, localRoomRules, remoteKeywords, replacementMap } = await import(
+  '../src/lib/store'
+)
+
+describe('replacement reactive rebuild (C4)', () => {
+  beforeEach(() => {
+    cachedRoomId.value = null
+    localGlobalRules.value = []
+    localRoomRules.value = {}
+    remoteKeywords.value = null
+    replacementMap.value = null
+  })
+
+  test('rebuilds when cachedRoomId resolves', () => {
+    localRoomRules.value = { 101: [{ from: 'foo', to: 'room-101' }] }
+    cachedRoomId.value = 101
+
+    expect(applyReplacements('foo')).toBe('room-101')
+  })
+
+  test('rebuilds when remoteKeywords change', () => {
+    cachedRoomId.value = 101
+    remoteKeywords.value = { global: { keywords: { foo: 'remote-v1' } } }
+    expect(applyReplacements('foo')).toBe('remote-v1')
+
+    remoteKeywords.value = { global: { keywords: { foo: 'remote-v2' } } }
+    expect(applyReplacements('foo')).toBe('remote-v2')
+  })
+
+  test('rebuilds when localGlobalRules change', () => {
+    cachedRoomId.value = 101
+    localGlobalRules.value = [{ from: 'foo', to: 'global-v1' }]
+    expect(applyReplacements('foo')).toBe('global-v1')
+
+    localGlobalRules.value = [{ from: 'foo', to: 'global-v2' }]
+    expect(applyReplacements('foo')).toBe('global-v2')
+  })
+
+  test('does NOT clobber a valid map when cachedRoomId resets to null mid-nav', () => {
+    cachedRoomId.value = 101
+    localRoomRules.value = { 101: [{ from: 'foo', to: 'room-101' }] }
+    expect(applyReplacements('foo')).toBe('room-101')
+
+    // Simulate ensureRoomId() momentarily resetting cachedRoomId between rooms.
+    // The map is preserved so concurrent applyReplacements calls don't see an
+    // incomplete (room-rule-less) map.
+    cachedRoomId.value = null
+
+    expect(applyReplacements('foo')).toBe('room-101')
+  })
+})

--- a/tests/utils-extract-room.test.ts
+++ b/tests/utils-extract-room.test.ts
@@ -1,0 +1,39 @@
+// Regression tests for the C2 audit fix: `extractRoomNumber` previously
+// returned the first numeric path segment for ANY URL, so non-room paths like
+// /p/eden/area-tags/12345 were treated as room 12345.
+
+import { describe, expect, test } from 'bun:test'
+
+import { extractRoomNumber } from '../src/lib/utils'
+
+describe('extractRoomNumber', () => {
+  test('parses canonical live room URLs', () => {
+    expect(extractRoomNumber('https://live.bilibili.com/12345')).toBe('12345')
+    expect(extractRoomNumber('https://live.bilibili.com/12345/')).toBe('12345')
+    expect(extractRoomNumber('https://live.bilibili.com/12345?broadcast_type=0')).toBe('12345')
+    expect(extractRoomNumber('https://live.bilibili.com/12345#anchor')).toBe('12345')
+  })
+
+  test('parses /blanc and /h5 popout shapes', () => {
+    expect(extractRoomNumber('https://live.bilibili.com/blanc/12345')).toBe('12345')
+    expect(extractRoomNumber('https://live.bilibili.com/h5/12345')).toBe('12345')
+  })
+
+  test('rejects non-room paths that contain numeric segments', () => {
+    expect(extractRoomNumber('https://live.bilibili.com/p/eden/area-tags/12345')).toBeUndefined()
+    expect(extractRoomNumber('https://live.bilibili.com/p/eden/area-tags/12345/')).toBeUndefined()
+    expect(extractRoomNumber('https://live.bilibili.com/some/12345/extra')).toBeUndefined()
+  })
+
+  test('rejects non-live hosts', () => {
+    expect(extractRoomNumber('https://www.bilibili.com/12345')).toBeUndefined()
+    expect(extractRoomNumber('https://space.bilibili.com/12345')).toBeUndefined()
+    expect(extractRoomNumber('https://attacker.example.com/12345')).toBeUndefined()
+  })
+
+  test('rejects roots and non-numeric paths', () => {
+    expect(extractRoomNumber('https://live.bilibili.com/')).toBeUndefined()
+    expect(extractRoomNumber('https://live.bilibili.com/notanumber')).toBeUndefined()
+    expect(extractRoomNumber('https://live.bilibili.com/blanc/')).toBeUndefined()
+  })
+})

--- a/tests/wbi-sentinel.test.ts
+++ b/tests/wbi-sentinel.test.ts
@@ -1,0 +1,68 @@
+// Regression test for the H-sec audit fix: the WBI hijack patches
+// XMLHttpRequest.prototype globally and previously had no double-install
+// guard, so re-running the install IIFE (e.g. in nested iframes that also
+// load the userscript) double-wrapped open/send.
+//
+// We verify the GUARD LOGIC — that an install IIFE shaped like the one in
+// `wbi.ts` short-circuits when the sentinel is already set. We don't test the
+// module-load side effect directly because other tests in this suite swap
+// `globalThis.XMLHttpRequest` for stubs and the prototype identity gets lost.
+
+import { describe, expect, mock, test } from 'bun:test'
+
+mock.module('$', () => ({
+  GM_deleteValue: () => {},
+  GM_getValue: <T>(_key: string, defaultValue: T): T => defaultValue,
+  GM_info: { script: { version: 'test' } },
+  GM_setValue: () => {},
+  unsafeWindow: globalThis,
+}))
+
+type SentinelTarget = { __chatterboxWbiHijackInstalled?: boolean; open: unknown; send: unknown }
+
+function fakeWbiInstall(proto: SentinelTarget): { installed: boolean } {
+  // Mirrors the IIFE in src/lib/wbi.ts.
+  const sentinel = '__chatterboxWbiHijackInstalled' as const
+  if (proto[sentinel]) return { installed: false }
+  proto[sentinel] = true
+  const originalOpen = proto.open
+  const originalSend = proto.send
+  proto.open = function (...args: unknown[]) {
+    return (originalOpen as (...a: unknown[]) => unknown).apply(this, args)
+  }
+  proto.send = function (...args: unknown[]) {
+    return (originalSend as (...a: unknown[]) => unknown).apply(this, args)
+  }
+  return { installed: true }
+}
+
+describe('WBI hijack sentinel guard', () => {
+  test('first install wraps the prototype and sets the sentinel', () => {
+    const proto: SentinelTarget = { open: () => 'orig-open', send: () => 'orig-send' }
+    const result = fakeWbiInstall(proto)
+    expect(result.installed).toBe(true)
+    expect(proto.__chatterboxWbiHijackInstalled).toBe(true)
+    // Wrapped function is a different reference but still callable.
+    expect(typeof proto.open).toBe('function')
+    expect(typeof proto.send).toBe('function')
+  })
+
+  test('second install bails out (no double-wrap, sentinel preserved)', () => {
+    const proto: SentinelTarget = { open: () => null, send: () => null }
+    fakeWbiInstall(proto)
+    const wrappedOpen = proto.open
+    const wrappedSend = proto.send
+
+    const second = fakeWbiInstall(proto)
+    expect(second.installed).toBe(false)
+    expect(proto.open).toBe(wrappedOpen)
+    expect(proto.send).toBe(wrappedSend)
+  })
+
+  test('the production wbi.ts module exposes the same sentinel name', async () => {
+    // Lock in the exact sentinel string so a refactor renaming it would fail
+    // here and prompt updating both sides.
+    const src = await Bun.file(`${import.meta.dir}/../src/lib/wbi.ts`).text()
+    expect(src.includes('__chatterboxWbiHijackInstalled')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Lands the Critical, High, and important Medium findings from the runtime audit.
Pure-function helpers were extracted/exported so each fix is covered by a unit-
test regression. **66 new `expect()` calls across 9 new test files**, plus
extensions to existing suites. CLAUDE.md compliance unchanged (still clean).

### Critical
- `live-ws-source`: precision-safe DedeUserID parsing for the WS auth uid
- `utils.extractRoomNumber`: requires `live.bilibili.com` host + trailing
  numeric path; rejects `/p/eden/area-tags/12345` etc.
- `api`: anchor lookups now run via `mapWithConcurrency` (cap 6) with an 8s
  AbortController per request
- `replacement`: auto-rebuild via `effect()`; skip clobbering a valid map when
  room id is mid-resolve
- `custom-chat-dom`: O(N) regex dedup replaced by `Map<eventKey, event>` +
  `WeakMap` key cache; size-threshold GC; bulk `splice` prune
- `custom-chat-dom`: native `MutationObserver` suspends while WS is `live`

### High security
- `wbi` / `fetch-hijack`: sentinel guards prevent double-wrap on iframe
  re-import; fast-path on non-matching URLs
- `guard-room-sync`: endpoint validation rejects non-http(s) and `http://` for
  non-loopback hosts
- `gm-signal` + `backup`: optional per-signal validator, `__version` check,
  type-mismatch entries dropped on import
- new `remote-keywords-sanitize` module: caps + `typeof` checks for
  `workers.vrp.moe` payloads

### High perf
- `trimRenderQueue` / `recordEventStats`: `while-shift` → single `splice`
- `custom-chat-style`: only reassigns `userStyleEl.textContent` when the CSS
  actually changed
- `auto-blend` 1s cleanup interval bails early when `trendMap` is empty

### High logic
- WS reconnect: 0–25% jitter on top of capped backoff
- `moderation.scanRestrictionSignals` + `durationFromData`: `WeakSet` visited
  guard against cyclic JSON
- `cachedRoomSlug` reactively resets whenever `cachedRoomId` is cleared

### Important Medium
- `recentDanmaku` key uses `\x00` separator (no `:` collision) + 500-entry cap
  + amortized cleanup
- AI-evasion: `isEvadedMessageSendable` rejects empty/whitespace results;
  empty sensitive-word entries skipped
- `gm-signal.flushPendingWrites` now also runs on `pagehide` /
  `visibilitychange=hidden`
- search-input handler debounced 120 ms

## Test plan

Local preflight (matches CI's `release.yml` and `runPreflightChecks()`):
- [x] `bun install --frozen-lockfile` — clean
- [x] `bun x biome ci .` — 133 files, 0 errors
- [x] `bun test` — **105 pass, 0 fail, 247 expect() calls** (was 39/99)
- [x] `bun run test:auto-blend` — 18/18 pass
- [x] `bun run build` — `dist/bilibili-live-wheel-auto-follow.user.js`
      680.67 kB / 185.80 kB gzip

CI:
- [ ] `Build and Deploy` workflow green on `audit/harden-runtime-findings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)