### PR TITLE
style(tests): fix biome ci on master (unblocks all PRs)

### DIFF
--- a/tests/auto-blend-blacklist.test.ts
+++ b/tests/auto-blend-blacklist.test.ts
@@ -30,7 +30,7 @@ describe('auto-blend blacklist', () => {
     expect(isAutoBlendBlacklistedUid(null)).toBe(false)
   })
 
-  test('returns false for empty-string uid (locks the `uid !== \'\'` short-circuit)', () => {
+  test("returns false for empty-string uid (locks the `uid !== ''` short-circuit)", () => {
     // Without the `uid !== ''` clause, `'' in {'': true}` could pass — and
     // worse, `'' in {}` happens to be false but `'' in {someKey: …}` is also
     // false, so this branch is only observable when blacklist actually has

--- a/tests/auto-blend-preset.test.ts
+++ b/tests/auto-blend-preset.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import {
-  AUTO_BLEND_PRESETS,
-  type AutoBlendPreset,
-  getAutoBlendPresetValues,
-} from '../src/lib/auto-blend-preset-config'
+import { AUTO_BLEND_PRESETS, type AutoBlendPreset, getAutoBlendPresetValues } from '../src/lib/auto-blend-preset-config'
 
 describe('auto-blend presets', () => {
   test('normal preset includes advanced safety defaults', () => {
@@ -83,18 +79,23 @@ describe('getAutoBlendPresetValues', () => {
   // The function spreads the preset and tacks on four hard-coded values.
   // Pin each tacked-on value across all three presets so the StringLiteral /
   // BooleanLiteral / number mutations get killed.
-  test.each(['safe', 'normal', 'hot'] as const)(
-    '%s preset: extra fields are requireDistinctUsers=true, sendCount=1, sendAllTrending=false, useReplacements=true',
-    (preset: AutoBlendPreset) => {
-      const v = getAutoBlendPresetValues(preset)
-      expect(v.requireDistinctUsers).toBe(true)
-      expect(v.sendCount).toBe(1)
-      expect(v.sendAllTrending).toBe(false)
-      expect(v.useReplacements).toBe(true)
-    }
-  )
+  test.each([
+    'safe',
+    'normal',
+    'hot',
+  ] as const)('%s preset: extra fields are requireDistinctUsers=true, sendCount=1, sendAllTrending=false, useReplacements=true', (preset: AutoBlendPreset) => {
+    const v = getAutoBlendPresetValues(preset)
+    expect(v.requireDistinctUsers).toBe(true)
+    expect(v.sendCount).toBe(1)
+    expect(v.sendAllTrending).toBe(false)
+    expect(v.useReplacements).toBe(true)
+  })
 
-  test.each(['safe', 'normal', 'hot'] as const)('%s preset: all base fields preserved verbatim', (preset: AutoBlendPreset) => {
+  test.each([
+    'safe',
+    'normal',
+    'hot',
+  ] as const)('%s preset: all base fields preserved verbatim', (preset: AutoBlendPreset) => {
     const base = AUTO_BLEND_PRESETS[preset]
     const v = getAutoBlendPresetValues(preset)
     expect(v.label).toBe(base.label)

--- a/tests/auto-blend-status.test.ts
+++ b/tests/auto-blend-status.test.ts
@@ -82,33 +82,23 @@ describe('formatAutoBlendStatus (branch ladder)', () => {
 
   test('cooldown remaining → "冷却中 Ns" (ceil to nearest second)', () => {
     // 5s left exactly
-    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 5000, now: 0 })).toBe(
-      '冷却中 5s'
-    )
+    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 5000, now: 0 })).toBe('冷却中 5s')
     // 4.5s left → ceil to 5
-    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 4500, now: 0 })).toBe(
-      '冷却中 5s'
-    )
+    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 4500, now: 0 })).toBe('冷却中 5s')
     // 1ms left → ceil to 1
-    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 1, now: 0 })).toBe(
-      '冷却中 1s'
-    )
+    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 1, now: 0 })).toBe('冷却中 1s')
   })
 
   test('cooldown expired or in the past → "观察中" (boundary at now === cooldownUntil)', () => {
     expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 0, now: 0 })).toBe('观察中')
     // cooldownUntil in the past → clamped to 0 → '观察中'
-    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 0, now: 1000 })).toBe(
-      '观察中'
-    )
+    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 0, now: 1000 })).toBe('观察中')
   })
 
   test('Math.max(0, …) prevents negative cooldown turning into "冷却中 -3s"', () => {
     // Without the clamp, (0 - 3000) / 1000 = -3 and `left > 0` is false,
     // but pinning the exact output catches any flip of `>` → `>=`.
-    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 0, now: 3000 })).toBe(
-      '观察中'
-    )
+    expect(formatAutoBlendStatus({ enabled: true, isSending: false, cooldownUntil: 0, now: 3000 })).toBe('观察中')
   })
 })
 

--- a/tests/custom-chat-css-sanitize.test.ts
+++ b/tests/custom-chat-css-sanitize.test.ts
@@ -205,9 +205,7 @@ describe('sanitizeCustomChatCss', () => {
     // whitespace-then-quote to "url(" with non-ws-then-quote. Match for
     // benign `url( "javascript:..." )` (with leading whitespace) should
     // still neutralize.
-    expect(
-      sanitizeCustomChatCss('.x { background: url( "javascript:alert(1)" ); }').removedUrlSchemes
-    ).toBe(1)
+    expect(sanitizeCustomChatCss('.x { background: url( "javascript:alert(1)" ); }').removedUrlSchemes).toBe(1)
     expect(sanitizeCustomChatCss('.x { background: url("javascript:alert(1)"); }').removedUrlSchemes).toBe(1)
   })
 

--- a/tests/custom-chat-pricing.test.ts
+++ b/tests/custom-chat-pricing.test.ts
@@ -111,7 +111,7 @@ describe('formatMilliyuanBadgeAmount', () => {
     expect(formatMilliyuanBadgeAmount(2500)).toBe('2.5元')
   })
 
-  test('passes empty-string symbol to underlying formatter (locks `formatMilliyuanAmount(amount, \'\')`)', () => {
+  test("passes empty-string symbol to underlying formatter (locks `formatMilliyuanAmount(amount, '')`)", () => {
     // Badge uses no currency prefix — the inner call must pass '' not '¥'.
     // Otherwise badge would output '¥1元' instead of '1元'.
     expect(formatMilliyuanBadgeAmount(1000)).toBe('1元')

--- a/tests/custom-chat-render.test.ts
+++ b/tests/custom-chat-render.test.ts
@@ -12,10 +12,10 @@ import type { CustomChatEvent, CustomChatKind } from '../src/lib/custom-chat-eve
 
 import {
   CUSTOM_CHAT_MAX_MESSAGES,
-  customChatBadgeType,
   type CustomChatBadgeType,
-  customChatPriority,
   type CustomChatPriority,
+  customChatBadgeType,
+  customChatPriority,
   shouldAnimateRenderBatch,
   shouldSuppressCustomChatEvent,
   takeRenderBatch,

--- a/tests/meme-content-key.test.ts
+++ b/tests/meme-content-key.test.ts
@@ -56,13 +56,7 @@ describe('memeContentKey (cross-source dedup key)', () => {
   test('full pipeline: LAPLACE + chatterbox-cloud variants collapse to same key', () => {
     // Same meme uploaded via different sources tends to differ on these
     // exact axes (extra whitespace, copy-pasted ZWSPs, case differences).
-    const variants = [
-      '哈哈哈',
-      '  哈哈哈  ',
-      '哈​哈​哈',
-      '哈　哈　哈',
-      '哈 哈 哈',
-    ]
+    const variants = ['哈哈哈', '  哈哈哈  ', '哈​哈​哈', '哈　哈　哈', '哈 哈 哈']
     const keys = variants.map(memeContentKey)
     // First two: trivially equal. Others should also equal '哈哈哈' or '哈 哈 哈'
     // depending on whether internal whitespace exists. Pin both buckets.

--- a/tests/moderation.test.ts
+++ b/tests/moderation.test.ts
@@ -355,9 +355,7 @@ describe('scanRestrictionSignals', () => {
   })
 
   test('string fields classify via classifyText', () => {
-    expect(
-      scanRestrictionSignals({ reason: '账号已注销' }, 'unit').some(s => s.kind === 'deactivated')
-    ).toBe(true)
+    expect(scanRestrictionSignals({ reason: '账号已注销' }, 'unit').some(s => s.kind === 'deactivated')).toBe(true)
     expect(scanRestrictionSignals({ reason: '拉黑了' }, 'unit').some(s => s.kind === 'blocked')).toBe(true)
     expect(scanRestrictionSignals({ reason: '黑名单' }, 'unit').some(s => s.kind === 'blocked')).toBe(true)
     expect(scanRestrictionSignals({ reason: 'On the blacklist' }, 'unit').some(s => s.kind === 'blocked')).toBe(true)

--- a/tests/remote-keywords-sanitize.test.ts
+++ b/tests/remote-keywords-sanitize.test.ts
@@ -190,7 +190,7 @@ describe('sanitizeRemoteKeywords', () => {
     // map as an array) and either crash or produce garbage room entries.
     expect(sanitizeRemoteKeywords({ rooms: null })).toEqual({})
     expect(sanitizeRemoteKeywords({ rooms: 'string' })).toEqual({})
-    expect(sanitizeRemoteKeywords({ rooms: { 'not': 'an array' } })).toEqual({})
+    expect(sanitizeRemoteKeywords({ rooms: { not: 'an array' } })).toEqual({})
     expect(sanitizeRemoteKeywords({ rooms: 42 })).toEqual({})
   })
 


### PR DESCRIPTION
## Summary
- Master HEAD was failing biome ci (8 errors across 9 test files), which made the `validate` job fail on every open Dependabot PR (#11–#15) and blocked merging.
- The mutation-testing commits introduced strings with escaped single-quotes (`\'\'`) and long-form `test.each` tuples that biome 2.4 reformats. Running `bun x biome check --write` produced this purely-mechanical fix.

## Changes
- 9 test files reformatted by biome (quote style, import folding, array layout). No behavior changes.

## Test plan
- [x] `bun x biome ci .` — passes locally
- [x] Full client test suite (`bun run test:client`) — 1989 pass / 0 fail
- [ ] `validate` green in CI