### PR TITLE
fix(ci): install deps before size-limit-action so vite is on PATH

### DIFF
--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - run: bun install --frozen-lockfile
       - uses: andresz1/size-limit-action@94bc357df29c36c8f8d50ea497c3e225c3c95d1d # v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -28,4 +28,4 @@ jobs:
           package_manager: bun
           build_script: build
           skip_step: install
-          script: bun x size-limit
+          script: bun x size-limit --json


### PR DESCRIPTION
## Summary
- The `size` workflow has been failing on every PR with `vite: command not found`.
- Root cause: `size-limit-action` has `skip_step: install`, and `oven-sh/setup-bun` only installs the bun binary (not project deps). When the action runs `build_script` (`tsc && vite build`), `vite` is not on PATH.
- Adding an explicit `bun install --frozen-lockfile` step between `setup-bun` and `size-limit-action` restores vite for the build.

## Test plan
- [ ] `size` job goes green on this PR.