### PR TITLE
fix(ci): coverage.yml — move DEEPSOURCE_DSN out of step-level if

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,13 @@ permissions:
 jobs:
   codecov:
     runs-on: ubuntu-latest
+    # `secrets` context is NOT allowed inside step-level `if:` expressions
+    # (GitHub Actions parse error: "Unrecognized named-value: 'secrets'").
+    # The supported pattern is to copy the secret to a job-level env var
+    # at workflow load time and then test `env.X` in the step's `if:`. The
+    # value is still masked in logs because it originated from `secrets`.
+    env:
+      DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
     steps:
       - uses: actions/checkout@v6
 
@@ -38,11 +45,9 @@ jobs:
         # which auto-executed whatever the upstream root URL served at run
         # time. SHA pinned to v1.1.3 (resolved 2026-05-11). Refreshable via:
         #   gh api repos/deepsourcelabs/test-coverage-action/git/refs/tags/v1.1.3 --jq .object.sha
-        if: ${{ secrets.DEEPSOURCE_DSN != '' }}
-        env:
-          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+        if: ${{ env.DEEPSOURCE_DSN != '' }}
         uses: deepsourcelabs/test-coverage-action@4284bb73a04adb39faaa6bfcc2d0e3dd137ffed7 # v1.1.3
         with:
           key: javascript
           coverage-file: ./coverage/lcov.info
-          dsn: ${{ secrets.DEEPSOURCE_DSN }}
+          dsn: ${{ env.DEEPSOURCE_DSN }}


### PR DESCRIPTION
## Summary

Coverage workflow has been failing since e29903f (audit commit) with **zero jobs and conclusion=failure**. \`gh workflow run\` surfaced the real error:

\`\`\`
(Line: 41, Col: 13): Unrecognized named-value: 'secrets'.
Located at position 1 within expression: secrets.DEEPSOURCE_DSN != ''
\`\`\`

GitHub Actions does not allow the \`secrets\` context inside step-level \`if:\`. The whole workflow gets rejected at load time, which is why master push runs had 0 jobs and no logs.

## Fix

Move \`DEEPSOURCE_DSN\` to the job-level \`env\` (read once at workflow load) and reference \`env.DEEPSOURCE_DSN\` in the step's \`if:\` and the action's \`dsn:\` input. The value is still log-masked because it came from \`secrets\`.

## Effect

- \`Coverage\` workflow starts running again on master push + PR
- \`DeepSource: Test coverage\` commit status stops timing out ("Waiting for artifact report...")
- Unblocks DeepSource analyzer findings on master

## Test plan

- [x] \`js-yaml\` parses fixed file cleanly
- [x] \`gh workflow run\` previously rejected the file with the exact error above; after this fix the workflow parses
- [ ] PR check shows \`codecov\` job actually runs (not 0-jobs failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)