### PR TITLE
fix(ci): make OSV scheduled scan report-only (master stays green)

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -48,3 +48,17 @@ jobs:
   scan-scheduled:
     if: github.event_name != 'pull_request'
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    with:
+      # Report-only on the scheduled / push scan. Master should stay green —
+      # the SARIF still uploads to the Security tab so existing transitive
+      # vulns stay visible for triage, but a freshly-disclosed CVE in some
+      # build-tool transitive dep won't suddenly turn master red. The PR
+      # scan above keeps `fail-on-vuln: true` (the default), so any *new*
+      # vuln introduced by a diff still blocks merging.
+      #
+      # As of 2026-05-12 master had 9 existing transitive vulns in
+      # build-only deps (brace-expansion/minimatch/picomatch/postcss/tmp
+      # via vite/biome/knip/stryker). None ship to the userscript or
+      # worker runtime; they exist only on CI runners during the build.
+      # Triage individually in the Security tab.
+      fail-on-vuln: false


### PR DESCRIPTION
## Why

Master push runs of OSV-Scanner have been failing because the full-tree scan trips on 9 existing transitive vulns:

| Package | Vuln paths | Where it comes from |
|---|---|---|
| \`brace-expansion 1.1.12\` | GHSA-f886-m6hf-6m8v | (lots of dev deps) |
| \`minimatch 3.0.8\` | GHSA-23c5-xmqv-rm74, -3ppc-4f35-3m26, -7r86-cg39-jmmj | glob ecosystem |
| \`picomatch 4.0.3\` | GHSA-3v7f-55p6-f55p, -c2c7-rcm5-vvqj | vite plugins |
| \`postcss 8.5.8\` | GHSA-qx2v-qp2m-jg93 | vite |
| \`tmp 0.0.33 / 0.1.0\` | GHSA-52f5-9888-hmc6 | external-editor (stryker), older glob |

All are **build-toolchain** deps. They do not ship in:

- the userscript bundle (vite/rollup tree-shake them out)
- the Cloudflare Worker (server/bun.lock has clean versions of all of these)

\`bun update\` cannot resolve — parent packages pin the bad versions. Only manual \`overrides\` in package.json would force them, with non-trivial risk of breaking parents (e.g. \`tmp\` 0.0/0.1 → 0.2 is a breaking API jump).

## Fix

Pass \`fail-on-vuln: false\` to the **scheduled** OSV scan (which runs on master push + cron). SARIF still uploads to the Security tab for triage. The **PR-only** scan above keeps the default \`fail-on-vuln: true\`, so any new vuln introduced by a diff still blocks merge — that's the gate that matters for change control.

Same pattern as \`semgrep.yml\` (\`semgrep ci ... || true\`).

## Test plan

- [x] YAML parses; \`scan-scheduled.with.fail-on-vuln === false\`
- [ ] Master post-merge: OSV-Scanner run completes without failure even when finding existing vulns
- [ ] PR scan still gates new vulns (this PR itself doesn't introduce any so we'll see this on the next PR that does)

🤖 Generated with [Claude Code](https://claude.com/claude-code)