### PR TITLE
fix(ci): set up Node 22 in fuzz-and-soak loadtest job for wrangler

### DIFF
--- a/.github/workflows/fuzz-and-soak.yml
+++ b/.github/workflows/fuzz-and-soak.yml
@@ -105,6 +105,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
       - run: bun install --frozen-lockfile
       - run: cd server && bun install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- The `loadtest` job in `.github/workflows/fuzz-and-soak.yml` was failing because `bunx wrangler d1 migrations apply ...` ran under the runner's default Node v20.20.2; recent Wrangler releases require Node ≥ v22.
- Added `actions/setup-node@v6` with `node-version: '22'` to the `loadtest` job only — matching the existing convention in `quality.yml` (knip / type-coverage) and `mutation.yml` (Stryker).
- `fuzz` and `soak` jobs are untouched — they don't invoke Wrangler.

## Test plan

- [x] `validate` CI check passes on this PR
- [ ] After merge: `gh workflow run fuzz-and-soak.yml --ref master` reaches at least the "Start wrangler dev (background)" step without the `Wrangler requires at least Node.js v22.0.0` error
- [ ] `fuzz` and `soak` jobs in the same run still pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)