### PR TITLE
fix(hzm-drive): SPA 切房间自动停车 + chore(deps): ws@^8.20.1 (CVE-2026-45736)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,9 @@
       },
     },
   },
+  "overrides": {
+    "ws": "^8.20.1",
+  },
   "packages": {
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
@@ -1141,7 +1144,7 @@
 
     "write-file-atomic": ["write-file-atomic@3.0.3", "", { "dependencies": { "imurmurhash": "^0.1.4", "is-typedarray": "^1.0.0", "signal-exit": "^3.0.2", "typedarray-to-buffer": "^3.1.5" } }, "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "wsl-utils": ["wsl-utils@0.3.1", "", { "dependencies": { "is-wsl": "^3.1.0", "powershell-utils": "^0.1.0" } }, "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg=="],
 
@@ -1246,8 +1249,6 @@
     "lighthouse/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
     "lighthouse/semver": ["semver@5.7.2", "", { "bin": { "semver": "bin/semver" } }, "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="],
-
-    "lighthouse/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "lighthouse/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "unocss": "^66.6.8",
     "vite": "^8.0.13",
     "vite-plugin-monkey": "^8.0.5"
+  },
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }

--- a/server/bun.lock
+++ b/server/bun.lock
@@ -16,6 +16,9 @@
       },
     },
   },
+  "overrides": {
+    "ws": "^8.20.1",
+  },
   "packages": {
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
 
@@ -337,7 +340,7 @@
 
     "wrangler": ["wrangler@4.92.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260515.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260515.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260515.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-/DKpQHPxkuZbQsO9dFW2700VTD/4DSZMHjy92fO/frNoDRi/zQsFCAd2ONCV6TGqcUoXcP3D8Bo2gj/L4M0qQQ=="],
 
-    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+    "ws": ["ws@8.20.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="],
 
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 

--- a/server/package.json
+++ b/server/package.json
@@ -23,5 +23,8 @@
     "vitest": "^4.1.0",
     "@cloudflare/vitest-pool-workers": "^0.16.3",
     "wrangler": "^4.92.0"
+  },
+  "overrides": {
+    "ws": "^8.20.1"
   }
 }

--- a/src/lib/hzm-auto-drive.ts
+++ b/src/lib/hzm-auto-drive.ts
@@ -30,6 +30,7 @@ import { subscribeDanmaku } from './danmaku-stream'
 import { formatHzmDriveStatus } from './hzm-drive-status'
 import { appendLog, notifyUser } from './log'
 import { enqueueDanmaku, SendPriority } from './send-queue'
+import { cachedRoomId } from './store'
 import {
   bumpDailyLlmCalls,
   bumpDailySent,
@@ -70,6 +71,23 @@ interface DanmuRecord {
 
 let recentDanmu: DanmuRecord[] = []
 let unsubscribe: (() => void) | null = null
+/**
+ * Dispose 房间切换观察者(SPA 切房间自动停车)。
+ *
+ * 智驾用模块级 `activeRoomId` 锁定启动时的房间。如果用户 SPA 切到新房间,`cachedRoomId`
+ * 变了但 `activeRoomId` 不变,tick 会用旧 roomId 继续 `enqueueDanmaku` 把旧房间的梗
+ * 发到新房间的 csrfToken 上(B 站会拒,但不一定每次拒;就算拒也会被风控记上一笔)。
+ *
+ * 修复方式:启动时记录 `activeRoomId`,然后 effect 监听 `cachedRoomId.value`;一旦
+ * 当前房间 ≠ 启动时的房间(且不是 null/还没解析出来),自动停车 + notifyUser。
+ *
+ * 为什么独轮车 / 自动跟车不需要这个修?
+ *  - 独轮车每轮调 `ensureRoomId()` 重新解析(loop.ts:80-85 注释),自然 follow 新房间。
+ *  - 自动跟车在 burst 触发时调 `ensureRoomId()`(auto-blend.ts:701),也自然 follow。
+ *  - **智驾不能 follow** —— 它绑了 `source.keywordToTag` 配置(灰泽满社区专属),
+ *    跨房间用旧源在新房间发完全是不相关内容。stop > follow。
+ */
+let roomChangeWatcher: (() => void) | null = null
 let tickTimer: ReturnType<typeof setTimeout> | null = null
 let pausedUntil = 0
 const sentTimestamps: number[] = []
@@ -586,6 +604,33 @@ export async function startHzmAutoDrive(opts: {
   activeSource = opts.source
   memesProvider = opts.getMemes
 
+  // SPA 切房间自动停车 —— 见 roomChangeWatcher 字段注释。
+  // effect 比 polling 更直接 + stopHzmAutoDrive() 时一并 dispose。
+  //
+  // 重要:effect 体里**不能**同步写 signal(notifyUser 会 push 到 logLines,
+  // hzmDriveEnabled 也是 signal),否则触发 "@preact/signals: Cycle detected"。
+  // 把实际动作放到 queueMicrotask,让 effect 只做检测。
+  roomChangeWatcher = effect(() => {
+    const current = cachedRoomId.value
+    // 还没解析出来(null)或还是启动时的房间 → 不做事。
+    if (current === null || current === activeRoomId) return
+    const fromRoom = activeRoomId
+    queueMicrotask(() => {
+      // 重新校验:有可能 effect 触发到 microtask 跑之间用户自己点了停车,
+      // 或者房间又切回原房间。
+      if (activeRoomId !== fromRoom) return
+      if (cachedRoomId.peek() === fromRoom) return
+      notifyUser(
+        'warning',
+        '智驾已停车',
+        `检测到你切到了新直播间,旧房间(${fromRoom})的智驾自动停了。需要时请在新房间重新开车。`
+      )
+      appendLog(`🛑 智驾自动停车:房间从 ${fromRoom} 切到 ${current}`)
+      hzmDriveEnabled.value = false
+      stopHzmAutoDrive()
+    })
+  })
+
   unsubscribe = subscribeDanmaku({
     onMessage: ev => {
       if (!ev.text) return
@@ -618,6 +663,10 @@ export function stopHzmAutoDrive(): void {
   if (unsubscribe) {
     unsubscribe()
     unsubscribe = null
+  }
+  if (roomChangeWatcher) {
+    roomChangeWatcher()
+    roomChangeWatcher = null
   }
   resetRuntime()
   updateHzmStatusText()

--- a/tests/hzm-auto-drive-lifecycle.test.ts
+++ b/tests/hzm-auto-drive-lifecycle.test.ts
@@ -84,6 +84,7 @@ const { _getRecentDanmuForTests, _runOneTickForTests, startHzmAutoDrive, stopHzm
 )
 const { logLines } = await import('../src/lib/log')
 const { getMemeSourceForRoom } = await import('../src/lib/meme-sources')
+const { cachedRoomId } = await import('../src/lib/store')
 const {
   hzmActivityMinDanmu,
   hzmActivityMinDistinctUsers,
@@ -129,6 +130,12 @@ beforeEach(() => {
   activeSubscription = null
   mockRoomId = ROOM
   mockCsrfToken = 'csrf-fixture'
+  // Production `ensureRoomId` sets `cachedRoomId.value = roomId` (api.ts:173),
+  // but our mock just returns mockRoomId without writing the signal. The room-
+  // change watcher in hzm-auto-drive reads cachedRoomId, so we must seed it
+  // here to ROOM, otherwise the previous test's leftover value would make the
+  // watcher think the user switched rooms and auto-stop the drive.
+  cachedRoomId.value = ROOM
   hzmDriveEnabled.value = true
   hzmDriveMode.value = 'heuristic'
   hzmDryRun.value = true
@@ -228,6 +235,69 @@ describe('startHzmAutoDrive — wiring', () => {
     await startHzmAutoDrive({ source, getMemes: () => POOL })
     expect(activeSubscription).toBeNull()
     expect(logLines.value.some(l => l.includes('不匹配'))).toBe(true)
+  })
+})
+
+describe('SPA room-change auto-stop', () => {
+  // 真问题:智驾用模块级 activeRoomId 锁定启动房间。SPA 切到新房间时 cachedRoomId
+  // 变,activeRoomId 不变 → tick 会用旧 roomId 发新房间的内容(或被 csrf 拒)。
+  // 修复:启动期 effect 监听 cachedRoomId,变了就 stopHzmAutoDrive() + 通知用户。
+  //
+  // 注意:独轮车 + 自动跟车 NOT NEED 这个修复 —— 它们在每轮 send 调 ensureRoomId()
+  // 自然跟新房间。只有智驾绑了 source 配置不能 follow,只能 stop。
+
+  test('cachedRoomId 切到新房间 → 自动停车 + 提示用户', async () => {
+    cachedRoomId.value = ROOM // 启动时房间
+    await startHzmAutoDrive({ source, getMemes: () => POOL })
+    expect(activeSubscription).not.toBeNull()
+    expect(hzmDriveEnabled.value).toBe(true)
+
+    // 模拟 SPA 切房间
+    cachedRoomId.value = 8888888
+    await flushMicrotasks()
+
+    // 智驾被自动停了
+    expect(hzmDriveEnabled.value).toBe(false)
+    expect(activeSubscription).toBeNull() // unsubscribe 被调
+    // 日志里有自动停车记录
+    expect(logLines.value.some(l => l.includes('自动停车') && l.includes(String(ROOM)))).toBe(true)
+  })
+
+  test('cachedRoomId 从 null → 启动房间(初始解析)不触发停车', async () => {
+    // 启动时 cachedRoomId 可能还没解析出来(null),effect 第一次跑看到 null 应该忽略,
+    // 否则启动 + 第一次 cachedRoomId 写入 = 假阳性停车。
+    cachedRoomId.value = null
+    await startHzmAutoDrive({ source, getMemes: () => POOL })
+    expect(hzmDriveEnabled.value).toBe(true)
+
+    // 现在 cachedRoomId 解析出来,等于 activeRoomId(启动时 ensureRoomId 返回的 mockRoomId=ROOM)
+    cachedRoomId.value = ROOM
+    await flushMicrotasks()
+
+    // 没停车
+    expect(hzmDriveEnabled.value).toBe(true)
+    expect(activeSubscription).not.toBeNull()
+  })
+
+  test('cachedRoomId 重复写同一房间号(re-emit)不触发停车', async () => {
+    cachedRoomId.value = ROOM
+    await startHzmAutoDrive({ source, getMemes: () => POOL })
+    cachedRoomId.value = ROOM // 同值再写
+    await flushMicrotasks()
+    expect(hzmDriveEnabled.value).toBe(true)
+  })
+
+  test('stopHzmAutoDrive() 后切房间不会再触发 notifyUser(watcher 已 dispose)', async () => {
+    cachedRoomId.value = ROOM
+    await startHzmAutoDrive({ source, getMemes: () => POOL })
+    stopHzmAutoDrive()
+    logLines.value = [] // 清掉启动日志
+
+    cachedRoomId.value = 9999999
+    await flushMicrotasks()
+
+    // 没有"自动停车"日志(watcher 已 dispose)
+    expect(logLines.value.some(l => l.includes('自动停车'))).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Jobs P2 后续两件:

### 1. 智驾切房间不自动停车的隐患 — `fix(hzm-drive):` 055c4c9

跟着 PR #36 Codex round-2 修复(mount gate stale-room guard)继续往下挖,发现底层 runtime 同样有跨房间残留。

`hzm-auto-drive` 用模块级 `activeRoomId` 锁定启动时的房间。SPA 切到新房间后 `cachedRoomId` 变了但 `activeRoomId` 不变 → tick 还会用旧 roomId 调 `enqueueDanmaku`(灰泽满的梗 → 新房间主播一脸懵 → 拉黑)。

**为什么独轮车 / 自动跟车不需要这个修?**
- 独轮车每轮 `ensureRoomId()` 重新解析([loop.ts:80-85](../blob/master/src/lib/loop.ts#L80-L85) 注释),自然 follow 新房间。
- 自动跟车 burst 触发时 `ensureRoomId()`([auto-blend.ts:701](../blob/master/src/lib/auto-blend.ts#L701)),也自然 follow。
- **智驾不能 follow** —— 它绑了 `source.keywordToTag` 配置(灰泽满社区专属),跨房间用旧源在新房间发完全是 garbage。stop > follow。

实现:`startHzmAutoDrive` 注册 `effect(() => cachedRoomId.value ...)` watcher,检测到房间变了且非 null 时 `queueMicrotask(() => stopHzmAutoDrive() + notifyUser)`。queueMicrotask 必要 —— 否则在 effect 同步体里写 signal 会触发 `@preact/signals: Cycle detected`。

测试 `tests/hzm-auto-drive-lifecycle.test.ts` +4 case 锁死行为(切房间停 / null→初始解析不误触发 / 同值再写不触发 / stop 后 watcher dispose)。

### 2. ws CVE-2026-45736 — `chore(deps):` 338adbe

OSV-Scanner 在 master 上报警:
- 根 lockfile `ws@8.20.0`(经 puppeteer-core@24.43.0 ← lighthouse@12.6.1)
- server lockfile `ws@8.18.0`(经 miniflare@4.20260507.1)

两者都在 CVE-2026-45736 / [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) 受影响范围(`ws >=8.0.0 <8.20.1`,"Uninitialized memory disclosure")。修复版本 `8.20.1`。

ws 是 transitive dep,加 npm-style `overrides: { "ws": "^8.20.1" }` 到两个 package.json 强制提到固定版本。两份 lockfile 重新解析,都到了 `ws@8.20.1`。

无运行时影响 —— lighthouse 只在 web-perf 调试,miniflare 只在 server tests,**都不进 userscript bundle**。

## Test plan

- [x] `bun run test:client` — 2482 pass / 0 fail / 159 files
- [x] `bun run build` — userscript 1.32 MB / 7.25s,无错
- [x] `bun x tsc --noEmit` clean
- [x] `bun x biome ci` 两个改动文件 clean
- [x] 两个 lockfile `grep -E '"ws@'` 都 → `ws@8.20.1`
- [ ] OSV-Scanner / DeepSource 在 PR 上重跑,确认 CVE alert 消失
- [ ] 装到 Tampermonkey 在灰泽满测试:开车 → 切到别的直播间 → 收到「智驾已停车」toast + 面板自动消失

🤖 Generated with [Claude Code](https://claude.com/claude-code)
